### PR TITLE
Edits necessary to run 3dvar once at least

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,7 +9,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_cmake.git
 local_path = ./@cmake
-tag = 1.0.5
+tag = 1.0.6
 externals = Externals.cfg
 protocol = git
 

--- a/src/Applications/GAAS_App/ana_aod.j.tmpl
+++ b/src/Applications/GAAS_App/ana_aod.j.tmpl
@@ -46,6 +46,8 @@ cat $aod_modis_pcf
 cat $aod_avhrr_pcf
 cat $AODWORK/ana.rc
 
+set ANAAODX = `which ana_aod.x`
+
 # external data directory
 #------------------------
 if ( !($?EXTDATA) ) then
@@ -66,6 +68,8 @@ else
        setenv AOD_NODEFILE 
    endif
 endif
+
+if ( $NCPUS_AOD == 1 ) setenv AOD_NODEFILE
 setenv MPIRUN "$AOD_NODEFILE $MPIRUN_AOD -np $NCPUS_AOD"
 
 # loop for two time steps
@@ -117,7 +121,7 @@ foreach time_offset ( 000000 030000 )
    #--------------
    if (-e ANAAOD_EGRESS) /bin/rm ANAAOD_EGRESS
    set flags = "-a $aod_a -d $aod_d -f $aod_f -k $aod_k"
-   ana_aod.x -v -x $EXPID $flags -o $ods_a $aer_f
+   $MPIRUN $ANAAODX -v -x $EXPID $flags -o $ods_a $aer_f
    if (! -e ANAAOD_EGRESS) then
       @ errcnt = $errcnt + 1
    endif

--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -7132,7 +7132,7 @@ if ( $fvchem && $lm > 2 ) {
  $ncpus_idf = $ncpus_iau;
 
 # Set NCPUS for PSAS-AOD analysis (wired)
- $ncpus_aod = 28;
+ $ncpus_aod = 1;
 
  open(SCRIPT,">$fvhome/run/$jobn.j") or
  die ">>> ERROR <<< cannot write $fvhome/run/$jobn.j";
@@ -7226,6 +7226,7 @@ print SCRIPT <<"EOF";
   setenv NCPUS_GSI   $ncpus_gsi   # Number of CPUs to run GSI
   setenv NCPUS_GPERT $ncpus_gpert # Number of CPUs to run gcmPERT
   setenv NCPUS_AOD   $ncpus_aod   # Number of CPUs to run PSAS-AOD
+  setenv GAAS_RUN_SLURM 1 # 1 = force GAAS/AOD to run in its own SLURM job, 0 = allow geosdas.csm to decide
 EOF
 if ($ncpus_per_node) {
 print SCRIPT <<"EOF";

--- a/src/Applications/GSI_App/CMakeLists.txt
+++ b/src/Applications/GSI_App/CMakeLists.txt
@@ -3,12 +3,15 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
    set (CMAKE_Fortran_FLAGS_RELEASE "${FOPT3} ${BIG_ENDIAN} ${BYTERECLEN} ${FP_MODEL_STRICT} ${ALIGNCOM}")
 endif ()
 
-ecbuild_add_executable (
-  TARGET gsi.x
-  SOURCES gsimain.F90
-  LIBS GEOSaana_GridComp GSI_GridComp GEOSgsi_Coupler 
-       NCEP_crtm NCEP_sfcio NCEP_bufr_r8i4 NCEP_nemsio NCEP_bacio_r4i4 NCEP_gfsio
-       NCEP_sp_r8i4 NCEP_w3_r8i4 nc_diag_read nc_diag_write)
+#####################################################################################
+# # Currently not installed in GNU Make                                             #
+# ecbuild_add_executable (                                                          #
+#   TARGET gsi.x                                                                    #
+#   SOURCES gsimain.F90                                                             #
+#   LIBS GEOSaana_GridComp GSI_GridComp GEOSgsi_Coupler                             #
+#        NCEP_crtm NCEP_sfcio NCEP_bufr_r8i4 NCEP_nemsio NCEP_bacio_r4i4 NCEP_gfsio #
+#        NCEP_sp_r8i4 NCEP_w3_r8i4 nc_diag_read nc_diag_write)                      #
+#####################################################################################
 
 ecbuild_add_executable (
   TARGET GSIsa.x


### PR DESCRIPTION
A final series of edits needed for me (@mathomp4) to run a c48 3dvar
test case. These include:

* Changes for ana_aod.x
   * Adding `GAAS_RUN_SLURM=1` to `fvsetup` a la Ops
   * Setting default AOD processors to 1 in `fvsetup` a la Ops
   * Using `esma_mpirun` in `ana_aod.j.tmpl`. @bmauer and I are not sure why this wasn't *always* needed in here. All these edits might not be necessary, but this worked, so we are committing for now. The changes were:
      * Adding an `ANAAODX` variable with the full path to `ana_aod.x` (see `g5das.j` for similar)
      * Blanking `AOD_NODEFILE`
      * Using `$MPIRUN`

Also, not compiling `gsi.x` as it isn't an installed program in CVS