### PR TITLE
Update ESMA_env for new g5_modules

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -2,7 +2,7 @@
 required = True
 repo_url = git@github.com:GEOS-ESM/ESMA_env.git
 local_path = ./@env
-tag = 1.1.2
+tag = 1.1.3
 protocol = git
 
 [ESMA_cmake]


### PR DESCRIPTION
g5_modules changed, so a new tag will be needed.

**NEEDS NEW RELEASE OF GEOS_env**