### PR TITLE
Fixes #31. Fix CMake issue for out-of-clone builds.

### DIFF
--- a/src/Applications/GEOSdas_App/testsuites/CMakeLists.txt
+++ b/src/Applications/GEOSdas_App/testsuites/CMakeLists.txt
@@ -20,6 +20,7 @@ if(GIT_FOUND)
       execute_process(
          COMMAND ${GIT_EXECUTABLE} merge-base --is-ancestor ${Project_WC_LATEST_TAG} ${Project_WC_REVISION_HASH}
          RESULT_VARIABLE is_latest_tag_an_ancestor
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
          )
       if (is_latest_tag_an_ancestor EQUAL 0)
          #message("Tag ${Project_WC_LATEST_TAG} is an ancestor of ${Project_WC_REVISION_HASH}")


### PR DESCRIPTION
This was an oversight on my part. As I was always testing with `build/` inside the clone, the git command always worked. But if you're not there, it will fail.

Even worse, if (for some reason) your build directory was in a *different* git repo, it would have used that repo for the commands!

Thanks to @aoloso and @kgerheiser  for finding this.

Unfortunately, for at least the v5.25.0 release, this is a bug to live with unless we push tags. As this is a relatively uncommon occurrence if people use `parallel_build.csh`, it probably isn't necessary. We can advise that "Matt got it wrong, and for now, put your build directory within the repo outside of src"