### PR TITLE
Fixes #38. Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,9 @@
 # GEOS ADAS Gatekeepers own all the files
 * @GEOS-ESM/adas-gatekeepers
 
+# Belt-and-suspender: ADAS Gatekeepers own Externals.cfg
+Externals.cfg @GEOS-ESM/adas-gatekeepers
+
 # The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
 CMakeLists.txt @GEOS-ESM/cmake-team
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,9 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
+# GEOS ADAS Gatekeepers own all the files
+* @GEOS-ESM/adas-gatekeepers
+
 # The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
 CMakeLists.txt @GEOS-ESM/cmake-team
 


### PR DESCRIPTION
This should make @GEOS-ESM/adas-gatekeepers the codeowner of all the `GEOSadas` fixture code