### PR TITLE
Update Externals with CPLFCST fix

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -88,7 +88,7 @@ protocol = git
 required = True
 repo_url = git@github.com:GEOS-ESM/CPLFCST_Etc.git
 local_path = ./src/Applications/@CPLFCST_Etc
-tag = v1.0.0
+tag = v1.0.1
 protocol = git
 
 [externals_description]


### PR DESCRIPTION
This is a trivial change to prevent CPLFCST from installing its own `.git` directory