### PR TITLE
Fixes #43. Add ${EXTENDED_SOURCE} flags

### DIFF
--- a/src/Applications/NCEP_Paqc/radcor/CMakeLists.txt
+++ b/src/Applications/NCEP_Paqc/radcor/CMakeLists.txt
@@ -44,6 +44,10 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
    string (REPLACE "${NO_ALIAS}" "" CMAKE_Fortran_FLAGS_RELEASE ${CMAKE_Fortran_FLAGS_RELEASE})
 endif ()
 
+if (EXTENDED_SOURCE)
+  set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${EXTENDED_SOURCE})
+endif()
+
 esma_add_library(${this}
   SRCS ${SRCS}
   DEPENDENCIES NCEP_bufr_r8i8

--- a/src/Applications/NCEP_Paqc/radcor/CMakeLists.txt
+++ b/src/Applications/NCEP_Paqc/radcor/CMakeLists.txt
@@ -44,10 +44,6 @@ if (CMAKE_Fortran_COMPILER_ID MATCHES Intel)
    string (REPLACE "${NO_ALIAS}" "" CMAKE_Fortran_FLAGS_RELEASE ${CMAKE_Fortran_FLAGS_RELEASE})
 endif ()
 
-if (EXTENDED_SOURCE)
-  set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${EXTENDED_SOURCE})
-endif()
-
 esma_add_library(${this}
   SRCS ${SRCS}
   DEPENDENCIES NCEP_bufr_r8i8
@@ -72,4 +68,8 @@ foreach (target ${this} raobcore.x hradcor.x read_prepbufr.x)
       target_compile_options (${target} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:${flag}>)
    endforeach ()
 endforeach ()
+
+if (EXTENDED_SOURCE)
+  set_target_properties (${this} PROPERTIES COMPILE_FLAGS ${EXTENDED_SOURCE})
+endif()
 


### PR DESCRIPTION
Per @gmao-msienkie, `m_ellipsoid.f` has a *perfect* cutoff where it compiles without extended source, but then has bad math!