### PR TITLE
Use CMake to ignore build and install directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@
 /@cmake/
 /@modules/
 /@env/
-/BUILD/
-/build*/
-/install*/
 /.mepo/
 parallel_build.o*
 log.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,3 +44,14 @@ include_directories(${MPI_Fortran_INCLUDE_PATH})
 add_subdirectory (@env)
 add_subdirectory (src)
 
+# https://www.scivision.dev/cmake-auto-gitignore-build-dir/
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+# Piggyback that file into install
+install(
+   FILES ${PROJECT_BINARY_DIR}/.gitignore
+   DESTINATION ${CMAKE_INSTALL_PREFIX}
+   )


### PR DESCRIPTION
A la https://github.com/GEOS-ESM/GEOSgcm/pull/258, use CMake itself to ignore build and install directories rather than assuming all build and install directories will be named `build` and `install`.