### PR TITLE
Update gitignore for mepo update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 *~
 /@cmake/
-/@modules/
+/cmake/
+/cmake@/
 /@env/
+/env/
+/env@/
 /.mepo/
 parallel_build.o*
 log.*

--- a/src/Applications/.gitignore
+++ b/src/Applications/.gitignore
@@ -1,4 +1,10 @@
 /@GEOSgcm_App
+/GEOSgcm_App
+/GEOSgcm_App@
 /@CPLFCST_Etc
+/CPLFCST_Etc
+/CPLFCST_Etc@
 /@UMD_Etc
+/UMD_Etc
+/UMD_Etc@
 

--- a/src/Components/.gitignore
+++ b/src/Components/.gitignore
@@ -1,4 +1,12 @@
 /@GEOSagcmPert_GridComp
+/GEOSagcmPert_GridComp
+/GEOSagcmPert_GridComp@
 /@GEOSana_GridComp
+/GEOSana_GridComp
+/GEOSana_GridComp@
 /@GEOSgcm_GridComp
+/GEOSgcm_GridComp
+/GEOSgcm_GridComp@
 /@g5pert
+/g5pert
+/g5pert@

--- a/src/Shared/.gitignore
+++ b/src/Shared/.gitignore
@@ -1,5 +1,12 @@
 /@GMAO_Shared
+/GMAO_Shared
+/GMAO_Shared@
 /@MAPL
+/MAPL
+/MAPL@
 /@NCEP_Shared
+/NCEP_Shared
+/NCEP_Shared@
 /@FMS
-/@GSW
+/FMS
+/FMS@


### PR DESCRIPTION
Soon, `mepo` will have the ability to checkout subrepos as `repo`, `repo@`, or `@repo`. This commit updates the `.gitignore` files to support this flexibility.