### PR TITLE
Update MOM5 to use relative remote

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -88,7 +88,7 @@ GEOSchem_GridComp:
 
 mom:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSogcm_GridComp/GEOSocean_GridComp/GuestOcean_GridComp/MOM_GEOS5PlugMod/@mom
-  remote: git@github.com:GEOS-ESM/MOM5.git
+  remote: ../MOM5.git
   tag: geos/v1.0.1
   develop: geos5
 


### PR DESCRIPTION
This one slipped by me. The MOM bit of `components.yaml` was using a hard-coded SSH URL which breaks the use of HTTPS urls.