### PR TITLE
bug fix for ADAS checking on LDAS job

### DIFF
--- a/src/Applications/GEOSdas_App/ldas_run.csh
+++ b/src/Applications/GEOSdas_App/ldas_run.csh
@@ -117,8 +117,9 @@ if ( $stage == 0 ) then
    set jobldas = "$LDHOME/run/lenkf.j"
    set jobIDlong = `$PBS_BIN/sbatch $jobldas`
    set jobID = `echo $jobIDlong  |awk -F'[ ]' '{print $4}'`
-   setenv ldasJobIDs  $jobID
-   echo $ldasJobIDs ": LDAS coupling lenkf jobID for central das "
+   echo $jobID > $FVWORK/ldasJobIDs.txt
+   ls -l $FVWORK/ldasJobIDs.txt
+   echo $jobID ": LDAS jobID for central das in ldasJobIDs.txt"
 
 ## back to fvwork 
    cd $FVWORK
@@ -127,10 +128,11 @@ if ( $stage == 0 ) then
 else 
    cd $FVWORK
    echo " ${MYNAME}: LDAS coupling: stage/link LdasIncr for AGCM corrector "
-   if ($?ldasJobIDs) then
-      $FVROOT/bin/jobIDfilter -w $ldasJobIDs
-   unsetenv ldasJobIDs
-   endif
+   set ldasJobIDs = `cat ldasJobIDs.txt`
+   echo " ldasJobIDs  :  ${ldasJobIDs} " 
+   $FVROOT/bin/jobIDfilter -w $ldasJobIDs
+   /bin/mv   $FVWORK/ldasJobIDs.txt  $FVWORK/ldasJobIDs.txt.${yyyymmddhh}
+   echo  " ${MYNAME}: job monitoring is done" 
 
    set lenkf_status_file = ${FVWORK}/lenkf_job_completed.txt
    rm -f $lenkf_status_file


### PR DESCRIPTION
This pull request fixes a problem with the ADAS checking on LDAS job completion within the LADAS.  The fix was added to PR #80 _after_ @rtodling had already pulled @saraqzhang's branch to his working branch.

The fix in the present pull request was constructed from Sara's recent commit [5fac454 (link to commit with white-space changes hidden)](https://github.com/GEOS-ESM/GEOSadas/pull/80/commits/5fac4547a982a5e8c032521774fd76c2c2de76c0?w=1), which included a couple of other, trivial changes.

The target branch of the present pull request is currently `feature/rtodling/GEOSadas-5_29_3_4LDAS`, but it is easy to redirect the pull request to a different branch by clicking `Edit` in the top right corner of this page and then changing the target branch to Ricardo's latest working branch.