### PR TITLE
Properly finalize GEOSgcmPert.x

### DIFF
--- a/src/Applications/GEOSgcmPert_App/GEOSgcmPert.F90
+++ b/src/Applications/GEOSgcmPert_App/GEOSgcmPert.F90
@@ -826,7 +826,8 @@ Program GEOS5_Main
    call ESMF_FieldBundleDestroy (LLPertBundle, __RC__)
    call t_p%stop('geosgcmpert.x')
    call MAPL_Finalize()
-!  call ESMF_Finalize (__RC__)
+   call pert_server%finalize()
+   call ESMF_Finalize (__RC__)
 
  end subroutine PERT_CAP
 


### PR DESCRIPTION
This fixes the random crashing that was being experienced when running this application with the latest tag.