### PR TITLE
fixing suggestion of $fvhome as top-level LDAS dir

### DIFF
--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -3405,10 +3405,10 @@ sub set_ldasANA {
           $ldas_flag = 1;
       }
 
-      $ans3 = query("LDAS HOME = $fvhome, full path?  ");
+      $ans3 = query("LDAS HOME = "$fvhome"_LDAS , full path?  ");
       $ldashome = $ans3 ;
 
-      $ans4 = query("LDAS HOME for land ensemble = $fvhome/run/atmens, full path?  ");
+      $ans4 = query("LDAS HOME for land ensemble = "$fvhome"_LDAS/run/atmens, full path?  ");
       $ldashome4ens = $ans4 ;
 
      } 


### PR DESCRIPTION
It doesn't make sense to suggest $fvhome as the top-level dir for the LDAS within the LADAS.  Replacing suggestion of $fvhome with $fvhome"_LDAS"