### PR TITLE
fcst and das (run) should use the same land setup

### DIFF
--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -9866,6 +9866,7 @@ sub copy_resources {
   #--ed_g5prog_rc_new("run","GCMPROG.rc.tmpl");
   ed_g5hist_rc_new("run","HISTORY.rc.tmpl");
   ed_g5surfGC_rc("run","GEOS_SurfaceGridComp.rc");
+  ed_g5surfGC_rc("fcst","GEOS_SurfaceGridComp.rc");
   writeSaverst($fcsthrs, "$fvhome/run");
   ed_blendacq("fcst");
 


### PR DESCRIPTION
somehow this does not show as a problem in most cases! For example, x0046a (and prePP) and x0045a - and other runs, the forecast reproduces the DAS during the period over IAU (as it should). The explanation for what is going on is provided by Rolf - quote here from email exchange:

> The fvpsas.log indicates that several Surface rc variables (see list below) were set explicitly in GEOS_SurfaceGridComp.rc, presumably because they have been uncommented by the setup script.  But all of these variables match the default setting that is encoded in the MAPL_GetResource() calls.  For example, in GEOS_SurfaceGridComp.F90, LAND_PARAMS defaults to "NRv7.2" when the LAND_PARAMS cannot be found in the resource file (as is the case in the run associated with prePP.gcm.log.*.txt):

if     (LSM_CHOICE.eq.1) then
       call MAPL_GetResource (SCF,  LAND_PARAMS,   label='LAND_PARAMS:',            DEFAULT="NRv7.2",   __RC__ )

And LAND_PARAMS is also set to "NRv7.2" if the corresponding line in the Surface rc file is simply uncommented without making other changes.

In a nutshell, the model defines defaults in two places, the rc file and the MAPL_GetResource() calls.  In recent tags, the respective defaults are consistent (which isn't true if you go back a year or so).  Specifying the default settings in the rc file only makes the defaults show up conveniently in the log file, but nothing else changes unless you specify non-default values in the rc file.


Also: this is being labeled here as zero-diff since it is (incidentally) so for the choices land in the x-exps and FP/FPP/prePP runs. It is not the case for forecasts using the Icarus land -but I don't believe anyone is truly using this option anymore.