### PR TITLE
Feature/msienkie/acft bc cleanup tails

### DIFF
--- a/src/Applications/GEOSdas_App/GEOSdas.csm
+++ b/src/Applications/GEOSdas_App/GEOSdas.csm
@@ -913,11 +913,11 @@ exit 1
 	  echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
 	  breaksw
      case 2:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,/g"  >> sed_file
+          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tails=.true./g"  >> sed_file
 	  echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
 	  breaksw
      case 3:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,/g"  >> sed_file
+          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tails=.true./g"  >> sed_file
 	  echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
 	  breaksw
      default:

--- a/src/Applications/GEOSdas_App/GEOSdas.csm
+++ b/src/Applications/GEOSdas_App/GEOSdas.csm
@@ -78,6 +78,7 @@
 #                       - Revise multi-incremental approach for 4d-analysis 
 #                         (cost goes down with successive updates)
 #                       - Temporarily leaving test lines commented out 
+#   8Dec2021 Sienkiewicz - add option for 'cleanup_tail' for aircraft bias correction
 #-----------------------------------------------------------------------------
 
 #
@@ -115,6 +116,7 @@
   if ( !($?BOOTSTRAP) )           setenv BOOTSTRAP     0
   if ( !($?CENTRAL_AGCM_PARALLEL) ) setenv CENTRAL_AGCM_PARALLEL 0
   if ( !($?CHECK_DMF) )           setenv CHECK_DMF     1
+  if ( !($?CLEANUP_TAIL) )        setenv CLEANUP_TAIL  0
   if ( !($?CONVPROG) )            setenv CONVPROG      0
   if ( !($?CONVSFC) )             setenv CONVSFC       0
   if ( !($?CONVUPA) )             setenv CONVUPA       0
@@ -913,11 +915,15 @@ exit 1
 	  echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
 	  breaksw
      case 2:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tail=.true.,/g"  >> sed_file
+          set cftstring = "aircraft_t_bc=.true.,"
+          if ( $CLEANUP_TAIL ) set cftstring = "$cftstring cleanup_tail=.true.,"
+          echo "s/>>>AIRCFT_BIAS<<</$cftstring/g"  >> sed_file
 	  echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
 	  breaksw
      case 3:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tail=.true.,/g"  >> sed_file
+          set cftstring = "aircraft_t_bc_pof=.true.,"
+          if ( $CLEANUP_TAIL ) set cftstring = "$cftstring cleanup_tail=.true.,"
+          echo "s/>>>AIRCFT_BIAS<<</$cftstring/g"  >> sed_file
 	  echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
 	  breaksw
      default:
@@ -1128,11 +1134,15 @@ exit 1
 	  echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
 	  breaksw
      case 2:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tail=.true./g"  >> sed_file
+          set cftstring = "aircraft_t_bc=.true.,"
+          if ( $CLEANUP_TAIL ) set cftstring = "$cftstring cleanup_tail=.true.,"
+          echo "s/>>>AIRCFT_BIAS<<</$cftstring/g"  >> sed_file
 	  echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
 	  breaksw
      case 3:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tail=.true./g"  >> sed_file
+          set cftstring = "aircraft_t_bc_pof.true.,"
+          if ( $CLEANUP_TAIL ) set cftstring = "$cftstring cleanup_tail=.true.,"
+          echo "s/>>>AIRCFT_BIAS<<</$cftstring/g"  >> sed_file
 	  echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
 	  breaksw
      default:

--- a/src/Applications/GEOSdas_App/GEOSdas.csm
+++ b/src/Applications/GEOSdas_App/GEOSdas.csm
@@ -913,11 +913,11 @@ exit 1
 	  echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
 	  breaksw
      case 2:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tails=.true./g"  >> sed_file
+          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tails=.true.,/g"  >> sed_file
 	  echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
 	  breaksw
      case 3:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tails=.true./g"  >> sed_file
+          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tails=.true.,/g"  >> sed_file
 	  echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
 	  breaksw
      default:

--- a/src/Applications/GEOSdas_App/GEOSdas.csm
+++ b/src/Applications/GEOSdas_App/GEOSdas.csm
@@ -913,11 +913,11 @@ exit 1
 	  echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
 	  breaksw
      case 2:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tails=.true.,/g"  >> sed_file
+          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tail=.true.,/g"  >> sed_file
 	  echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
 	  breaksw
      case 3:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tails=.true.,/g"  >> sed_file
+          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tail=.true.,/g"  >> sed_file
 	  echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
 	  breaksw
      default:
@@ -1128,11 +1128,11 @@ exit 1
 	  echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
 	  breaksw
      case 2:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,/g"  >> sed_file
+          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tail=.true./g"  >> sed_file
 	  echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
 	  breaksw
      case 3:
-          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,/g"  >> sed_file
+          echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tail=.true./g"  >> sed_file
 	  echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
 	  breaksw
      default:

--- a/src/Applications/GSI_App/fvssi
+++ b/src/Applications/GSI_App/fvssi
@@ -742,11 +742,11 @@
                  echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
                  breaksw
             case 2:
-                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tails=.true./g"  >> sed_file
+                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tails=.true.,/g"  >> sed_file
                  echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
                  breaksw
             case 3:
-                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tails=.true./g"  >> sed_file
+                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tails=.true.,/g"  >> sed_file
 	         echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
                  breaksw
             default:

--- a/src/Applications/GSI_App/fvssi
+++ b/src/Applications/GSI_App/fvssi
@@ -53,6 +53,7 @@
   if ( !($?ANA4DUPD_IAU0_ONLY) ) setenv ANA4DUPD_IAU0_ONLY 0 # assume 4d increment
   if ( !($?ANGLEBC) )    setenv ANGLEBC  0
   if ( !($?BATCH_SUBCMD)  )  setenv BATCH_SUBCMD "sbatch"
+  if ( !($?CLEANUP_TAIL) )        setenv CLEANUP_TAIL  0
   if ( !($?DATAMOVE_CONSTRAINT)  )  setenv DATAMOVE_CONSTRAINT NULL
   if ( !($?INCSENS)   )  setenv INCSENS 0
   if ( !($?GSI_NETCDF_DIAG) )  setenv GSI_NETCDF_DIAG 0
@@ -742,11 +743,15 @@
                  echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
                  breaksw
             case 2:
-                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tail=.true.,/g"  >> sed_file
+                 set cftstring = "aircraft_t_bc=.true.,"
+                 if ( $CLEANUP_TAIL ) set cftstring = "$cftstring cleanup_tail=.true.,"
+                 echo "s/>>>AIRCFT_BIAS<<</$cftstring/g"  >> sed_file
                  echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
                  breaksw
             case 3:
-                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tail=.true.,/g"  >> sed_file
+                 set cftstring = "aircraft_t_bc_pof=.true.,"
+                 if ( $CLEANUP_TAIL ) set cftstring = "$cftstring cleanup_tail=.true.,"
+                 echo "s/>>>AIRCFT_BIAS<<</$cftstring/g"  >> sed_file
 	         echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
                  breaksw
             default:
@@ -842,11 +847,15 @@
            echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
            breaksw
       case 2:
-           echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tail=.true.,/g"  >> sed_file
+           set cftstring = "aircraft_t_bc=.true.,"
+           if ( $CLEANUP_TAIL ) set cftstring = "$cftstring cleanup_tail=.true.,"
+           echo "s/>>>AIRCFT_BIAS<<</$cftstring/g"  >> sed_file
            echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
            breaksw
       case 3:
-           echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tail=.true.,/g"  >> sed_file
+           set cftstring = "aircraft_t_bc_pof=.true.,"
+           if ( $CLEANUP_TAIL ) set cftstring = "$cftstring cleanup_tail=.true.,"
+           echo "s/>>>AIRCFT_BIAS<<</$cftstring/g"  >> sed_file
 	         echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
            breaksw
       default:
@@ -984,6 +993,7 @@ ENVIRONMENT VARIABLES
 ENVIRONMENT VARIABLES (optional)
 
   ACFTBIAS    sets aircraft bias correction
+  CLEANUP_TAIL  triggers cleanup of aircraft coefficient file
   ANASENS     trigger for analysis sensitivity (obs impact)
   INCSENS     allows running adjoint GSI with analysis increment for input
   DO4DVAR     trigger for 4DVAR-related features

--- a/src/Applications/GSI_App/fvssi
+++ b/src/Applications/GSI_App/fvssi
@@ -742,11 +742,11 @@
                  echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
                  breaksw
             case 2:
-                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,/g"  >> sed_file
+                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tails=.true./g"  >> sed_file
                  echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
                  breaksw
             case 3:
-                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,/g"  >> sed_file
+                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tails=.true./g"  >> sed_file
 	         echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
                  breaksw
             default:

--- a/src/Applications/GSI_App/fvssi
+++ b/src/Applications/GSI_App/fvssi
@@ -742,11 +742,11 @@
                  echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
                  breaksw
             case 2:
-                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tails=.true.,/g"  >> sed_file
+                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tail=.true.,/g"  >> sed_file
                  echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
                  breaksw
             case 3:
-                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tails=.true.,/g"  >> sed_file
+                 echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tail=.true.,/g"  >> sed_file
 	         echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
                  breaksw
             default:

--- a/src/Applications/GSI_App/fvssi
+++ b/src/Applications/GSI_App/fvssi
@@ -842,11 +842,11 @@
            echo 'Setting aircraft_t_bc_ext to true, using external bias correction'
            breaksw
       case 2:
-           echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,/g"  >> sed_file
+           echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc=.true.,cleanup_tail=.true.,/g"  >> sed_file
            echo 'Setting aircraft_t_bc to true, using VV.VV^2 bias correction'
            breaksw
       case 3:
-           echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,/g"  >> sed_file
+           echo "s/>>>AIRCFT_BIAS<<</aircraft_t_bc_pof=.true.,cleanup_tail=.true.,/g"  >> sed_file
 	         echo 'Setting aircraft_t_bc_pof to true, using POF bias correction'
            breaksw
       default:


### PR DESCRIPTION
Modifications made to 'GEOSdas.csm' and 'fvssi' scripts to add the 'cleanup_tail=.true.' flag to the options for the two aircraft varBC methods.  
The cleanup_tail process removes any entries from the aircraft temperature bias correction file that have not been updated for more than a year.  This helps limit the size of the aircraft coefficient file.

When a particular tail number has no reports the bias correction coefficients and their background error are kept the same until that particular tail number resumes reports again - the background error is not inflated.  Thus, this change will not be zero diff in the case where an aircraft reappears.  If a tail has been missing for more than a year it is probably beneficial to discard the bias correction since the characteristics of the aircraft equipment may have changed or the equipment may have been replaced during the downtime.   
