### PR TITLE
ADAS Gatekeepers should be notified of all changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,11 +8,11 @@
 
 # The GCM gatekeepers and CMake should know/approve these
 /.github/    @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers
-/.circleci/    @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers
-/.codebuild/    @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers
+/.circleci/  @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers
+/.codebuild/ @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers
 
-# The GEOS CMake Team is the CODEOWNER for the CMakeLists.txt files in this repository
-CMakeLists.txt @GEOS-ESM/cmake-team
+# The GEOS CMake Team should be notified for changes to CMakeLists.txt files in this repository
+CMakeLists.txt @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers
 
 # The GEOS CMake Team should be notified about and approve config changes
-/config/       @GEOS-ESM/cmake-team
+/config/ @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # GEOS ADAS Gatekeepers own all the files
 * @GEOS-ESM/adas-gatekeepers
 
-# The GCM gatekeepers and CMake should know/approve these
+# The ADAS gatekeepers and CMake should know/approve these
 /.github/    @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers
 /.circleci/  @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers
 /.codebuild/ @GEOS-ESM/cmake-team @GEOS-ESM/adas-gatekeepers


### PR DESCRIPTION
Just realized that @GEOS-ESM/adas-gatekeepers were not co-owners of CMake and sparsing files. That was a mistake on my end setting up the `CODEOWNERS` file. This fixes that to make sure they are!