### PR TITLE
Update the readme file with a note about the 'generic' configuration

### DIFF
--- a/src/Applications/NCEP_Etc/NCEP_bias/init_coeffs.f90
+++ b/src/Applications/NCEP_Etc/NCEP_bias/init_coeffs.f90
@@ -613,7 +613,8 @@ program init_coeffs
      obstype = gsi_files(iii)%dtype
 
      select case (trim(obstype))
-     case ('sndr','sndrd1','sndrd2','sndrd3','sndrd4','ssmi','ssmis','seviri','tmi','gmi','avhrr')
+     case ('sndr','sndrd1','sndrd2','sndrd3','sndrd4','ssmi','ssmis',         &
+               'seviri','tmi','gmi','avhrr','geoirs')
         mean_only = .true.
         np = 1
      case default

--- a/src/Applications/NCEP_Etc/NCEP_bias/readme_init_coeffs.txt
+++ b/src/Applications/NCEP_Etc/NCEP_bias/readme_init_coeffs.txt
@@ -45,6 +45,15 @@ directory with names in the format
      %s.diag_(dtype)_(dplat)_ges.%y4%m2%d2_%h2z.bin
 where the %s is substituted with the expid specified on the command line
 
+Note: this program uses the "gsi.rc.tmpl" file to get values for 'dtype',
+'dplat', and 'dsis' for each satellite instrument being fitted.  The 'dtype'
+and 'dplat' are used in determining the names of the diag files to read. 
+The 'dsis' indicates the entries in the "satbias" file to contain the results
+of the coefficient fitting.  If you are using the 'generic' method in your
+"gsi.rc.tmpl" to configure your instrument you will need to supply another
+file with an 'OBS_INPUT::' table like in the "gsi.rc.tmpl" which specifies
+the 'dtype', 'dplat' and 'dsis' values for your satellite(s).
+
 --------------------- EXAMPLES --------------------------------------------
 
 1) Using archived diag_*_ges.*.bin files as input

--- a/src/Applications/NCEP_Etc/NCEP_bias/readme_init_coeffs.txt
+++ b/src/Applications/NCEP_Etc/NCEP_bias/readme_init_coeffs.txt
@@ -45,14 +45,12 @@ directory with names in the format
      %s.diag_(dtype)_(dplat)_ges.%y4%m2%d2_%h2z.bin
 where the %s is substituted with the expid specified on the command line
 
-Note: this program uses the "gsi.rc.tmpl" file to get values for 'dtype',
-'dplat', and 'dsis' for each satellite instrument being fitted.  The 'dtype'
-and 'dplat' are used in determining the names of the diag files to read. 
-The 'dsis' indicates the entries in the "satbias" file to contain the results
-of the coefficient fitting.  If you are using the 'generic' method in your
-"gsi.rc.tmpl" to configure your instrument you will need to supply another
-file with an 'OBS_INPUT::' table like in the "gsi.rc.tmpl" which specifies
-the 'dtype', 'dplat' and 'dsis' values for your satellite(s).
+Note: Since this program uses the "gsi.rc.tmpl" file to get values for 'dtype',
+'dplat', and 'dsis' for each satellite instrument being fitted, if you are 
+using the 'generic' value for these variables in your "gsi.rc.tmpl" to 
+configure your instrument you will need to supply another file with an 
+'OBS_INPUT::' table like in the "gsi.rc.tmpl" which specifies the actual
+'dtype', 'dplat' and 'dsis' values for your satellite(s).
 
 --------------------- EXAMPLES --------------------------------------------
 


### PR DESCRIPTION
Updated the readme_init_coeffs file with a note about how it uses the 'gsi.rc.tmpl' to get 'dtype', 'dplat' and 'dsis' for each satellite.  