### PR TITLE
Modify prepqc script to check for pre-qc data and skip if no data is present

### DIFF
--- a/src/Applications/GEOSdas_App/GEOSdas.csm
+++ b/src/Applications/GEOSdas_App/GEOSdas.csm
@@ -1969,9 +1969,11 @@ exit 1
         endif
      endif
 
-     set ars_list = ( satbias satbang )
+     set ars_list = ( satbias )
      if ($NEWRADBC || $ANGLEBC) then
        set ars_list = ( $ars_list satbiaspc )
+     else if ( ! $ANGLEBC ) then
+       set ars_list = ( $ars_list satbang )
      endif
      if ($ACFTBIAS) then
        set ars_list = ( $ars_list acftbias )
@@ -2972,27 +2974,35 @@ endif
          /bin/rm -f input_combfr.txt
          touch input_combfr.txt
          foreach qcpat ( `cat pre-qc.acq | sort | uniq`)
-            echorc.x -template dummy $nymdb $nhmsb -fill $qcpat >> input_combfr.txt
+#           echorc.x -template dummy $nymdb $nhmsb -fill $qcpat >> input_combfr.txt
+            set fn = `echorc.x -template dummy $nymdb $nhmsb -fill $qcpat`
+            if ( -e $fn && ! -z $fn ) echo $fn >> input_combfr.txt
          end
-         combfrd.x -d $pbdtg $pbname < input_combfr.txt
-         scanbuf0.x  $pbname >! data_types.log
 
-         if ( `grep PROFLR data_types.log | wc -l `) then
-           setenv PROFQC 1
+         if ( -z input_combfr.txt) then
+# if no files to combine then no input for prepqc, so try setting prepqc 0
+            if ($PREPQC) setenv PREPQC        0
          else
-           setenv PROFQC 0
-         endif
+            combfrd.x -d $pbdtg $pbname < input_combfr.txt
+            scanbuf0.x  $pbname >! data_types.log
 
-         if ( `grep AIRCFT data_types.log | wc -l`) then
-           setenv ACFTQC 1
-         else
-           setenv ACFTQC 0
-         endif
+            if ( `grep PROFLR data_types.log | wc -l `) then
+              setenv PROFQC 1
+            else
+              setenv PROFQC 0
+            endif
 
-         if  ( `grep AIRCAR data_types.log | wc -l`) then
-           setenv ACARSQC 1
-         else
-           setenv ACARSQC 0
+            if ( `grep AIRCFT data_types.log | wc -l`) then
+              setenv ACFTQC 1
+            else
+              setenv ACFTQC 0
+            endif
+
+            if  ( `grep AIRCAR data_types.log | wc -l`) then
+              setenv ACARSQC 1
+            else
+              setenv ACARSQC 0
+            endif
          endif
       endif
    endif

--- a/src/Applications/NCEP_Paqc/oiqc/prepqc_daemon.pl
+++ b/src/Applications/NCEP_Paqc/oiqc/prepqc_daemon.pl
@@ -88,9 +88,14 @@ while(1) { # Start the daemon
                 open(FH1,"+>input_combfr.txt") || die "prepqc: could not open input_combfr.txt";
                 foreach $qcpat ( `cat pre-qc.acq | sort | uniq`) {
                     $pat = `echorc.x -template dummy $nymd $nhms -fill $qcpat`;
-                    print FH1 ("$pat");
+                    print FH1 ("$pat") if ( -e $pat  && ! -z $pat ) ;
                 }
                 close(FH1);
+                if ( -z "input_combfr.txt "{
+                   print"No pre-qc files present, skipping PREPQC\n";
+                   system("touch prepqc.$nymd.$nhms.done");
+                   return
+                }
                 `combfrd.x -d $pbdtg $pbname < input_combfr.txt`;
                 open(FH1,"+>data_types.log") || die "prepqc: could not open data_types.log";
                 @types = `scanbuf0.x  $pbname`;


### PR DESCRIPTION
Originally the prepqc script determined the templates for the 'pre-qc' files to be combined and passed through 'prepqc' by checking the output of the 'acquire_obsys' command.  A few years ago the DAS was modified to obtain the templates for the 'pre-qc' files by checking the OBSCLASS and obtaining the templates from the obsys.rc.  This was necessary because the 'acquire_obsys' was being run several times and the obsys.acq output from e.g. the acquire of aerosol data was overwriting the the acquire of the GSI observations. 
The problem with this is the 'obsys.acq' had previously only had filename templates for data that was actually acquired for the segment while the newer method obtained templates for all of the files with pre-qc OBSCLASS entries even if the data was not being obtained.
This script adds a check that each pre-qc file exists before the filename is added to the input to the 'combfrd.x' program that combines the prepbufr file.  If there are no matching pre-qc files present, the rest of the prepqc related processing is skipped.
Among other things, this allows a DAS run to transition between MERRA2/GEOSIT/R21c reanalysis data streams to the real-time GDAS stream (which does not need and should not have 'prepqc' processing performed on it) without having to stop and reconfigure.  The obsys.rc file can be configured to use the 'pre-qc' files up to a certain date and the real-time files after that date.
The GEOSdas.csm modifications have been tested.  There are similar modifications in 'prepqc_daemon.pl' that have not been tested since it doesn't look like that script is being used in current runs.

I have also made a small change that will hopefully remove the dependency on having the unneeded ana_satbang_rst file in the restart files.  A test has been set up running with the old VarBC to verify that the ana_satbang_rst file will be handled correctly for that case.