### PR TITLE
oiqcbufr.f adjust format for printout

### DIFF
--- a/src/Applications/NCEP_Paqc/oiqc/oiqcbufr.f
+++ b/src/Applications/NCEP_Paqc/oiqc/oiqcbufr.f
@@ -2127,7 +2127,7 @@ C  ---------------------------------------
          WRITE(6 ,30)ITRY,NFG,NFB,NFL,NBB,NCK
       endif
 
-30    FORMAT('ITERATION ',I2,' : NFLIP=',3I6,' NBAD=',I6,' NTOT=',I6)
+30    FORMAT('ITERATION ',I2,' : NFLIP=',3I6,' NBAD=',I6,' NTOT=',I7)
 
 C  FINISHED YET?
 C  -------------


### PR DESCRIPTION
Need a cosmetic change to avoid ***** in OIQC printout
NTOT too large for I6 format in printout for stats from upper level check  - increase to I7

