### PR TITLE
Fix for RO FSOI diag.bin issue

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -28,7 +28,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.10.3
+  tag: v1.4.10.4
   develop: main
 
 MAPL:
@@ -46,7 +46,7 @@ FMS:
 GEOSana_GridComp:
   local: ./src/Components/@GEOSana_GridComp
   remote: ../GEOSana_GridComp.git
-  tag: v1.5.4.7
+  tag: v1.5.4.8
   develop: develop
 
 GEOSgcm_GridComp:
@@ -121,7 +121,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.5.6.2
+  tag: v1.5.6.3
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
Update other repos - no change to fixtures:

GEOSana - fix for RO diag.bin error that made FSOI got bad
GMAO_Shared - update restricted RO database (consistent w/ x0046d - summer)
GEOSgcm_App - revise regrid-method for few FP streams

zero diff as long as FSOI is not running; otherwise it fixes an error there.