### PR TITLE
GEOSadas should ignore Held-Suarez related files

### DIFF
--- a/config/GEOSgcm_GridComp.sparse
+++ b/config/GEOSgcm_GridComp.sparse
@@ -1,3 +1,5 @@
 /*
+!/GEOSagcm_GridComp/GEOS_AgcmSimpleGridComp.F90
+!/GEOSagcm_GridComp/GEOShs_GridComp
 !/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/ARIESg3_GridComp
 !/GEOSagcm_GridComp/GEOSsuperdyn_GridComp/FVdycore_GridComp


### PR DESCRIPTION
Recently in the GEOSgcm, @pchakraborty added support for the Held-Suarez model (used in GPU work) but it is *ignored* by the GEOSgcm by default by sparsing it out (see https://github.com/GEOS-ESM/GEOSgcm/pull/591). 

This PR brings the same sparsing here. This was uncovered in MAPL CI as the GEOSadas builds were all failing on some OpenACC calls because it was seeing the Held-Suarez code.