### PR TITLE
Update to GMAO_Shared v1.9.4

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -28,7 +28,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.9.3
+  tag: v1.9.4
   develop: main
 
 GEOS_Util:


### PR DESCRIPTION
In response to https://github.com/GEOS-ESM/GMAO_Shared/pull/333, GMAO_Shared v1.9.4 was released:

https://github.com/GEOS-ESM/GMAO_Shared/releases/tag/v1.9.4

This PR updates to it (and this way @rtodling can approve and merge when he's able). (Note: Marking 0-diff as the GMAO_Shared PR was.)