### PR TITLE
FP patch:OMPS-LP & GOES-18

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -28,7 +28,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.10.5-GEOS-FP-1
+  tag: v1.4.10.5-GEOS-FP-2
   develop: main
 
 MAPL:
@@ -46,7 +46,7 @@ FMS:
 GEOSana_GridComp:
   local: ./src/Components/@GEOSana_GridComp
   remote: ../GEOSana_GridComp.git
-  tag: v1.5.4.8-GEOS-FP-1
+  tag: v1.5.4.8-GEOS-FP-2
   develop: develop
 
 GEOSgcm_GridComp:


### PR DESCRIPTION
This provides:

1) transition from GOES-17 to 18 (non-zero-diff)
2) better prep for turning on OMPS-LP if/when desired (zero-diff, if obs class not used).