### PR TITLE
allow overwrite of model output

### DIFF
--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/R21C/HISTAENS.rc.tmpl
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/R21C/HISTAENS.rc.tmpl
@@ -5,6 +5,7 @@
 VERSION: 1
 EXPID:  >>>EXPID<<<
 EXPDSC: ensemble_bkg
+Allow_Overwrite: .true.
  
 GRID_LABELS: PC288x181-DC
 	     PE90x540-CF	


### PR DESCRIPTION
Yesterday I ran into an issue w/ MAPL that I find it quite unpleasant in many respects – I stumbled on this in the past – had a exchanged w/ the SI group, they reset the default, but apparently that come back in more recent versions MAPL as being set w/ the undesirable default.

This is related to an knob placed in MAPL to prevent CFIO from overwriting any nc4 output. The way I stumbled on this yesterday was but doing some tests w/ the model; running on an interactive queue and re-running the model over a segment that had already been run w/ - and having the GCM crash on me saying that it could not overwrite its output. 

In general this is an annoyance for debugging such as I was doing, but it hit me this morning that this is more than just an annoyance. This would make restarting the ensemble, in case of sporadic random crashes, really painful – essentially this is break the auto-restart of the ensembles. 

I checked the M21C source code and from what I can tell it too has the inconvenient default. 

I checked w/ SI group – they agree w/ me this is inconvenient – and told me there is a global flag that can be put in the history that tells cfio not to bother. 

I am putting this here - you can decide if you want it.

 **BTW: I was looking at the @GEOSgcm_App as I would expect to find a M21C or R21C history there ... but I don't see one! Did we missing something in the commit?** 

