### PR TITLE
Updates for M21C

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -58,7 +58,7 @@ GEOSana_GridComp:
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v1.18.1+R21C_v1.0.0
+  tag: v1.18.1+R21C_v1.0.1
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: R21C
 
@@ -107,7 +107,7 @@ geos-chem:
 GOCART:
   local: ./src/Components/@GEOSgcm_GridComp/GEOSagcm_GridComp/GEOSphysics_GridComp/@GEOSchem_GridComp/@GOCART
   remote: ../GOCART.git
-  tag: v2.1.2+R21C_v1.0.1
+  tag: v2.1.2+R21C_v1.0.2
   develop: R21C
 
 QuickChem:
@@ -182,7 +182,7 @@ RRTMGP:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.9.6+R21C_v1.0.1
+  tag: v1.9.6+R21C_v1.0.2
   develop: R21C
 
 Ocean-LETKF:

--- a/src/Applications/GEOSdas_App/edhist.pl
+++ b/src/Applications/GEOSdas_App/edhist.pl
@@ -1127,7 +1127,9 @@ sub plot_edit {
     foreach $name (@topList) {
         $name =~ s/_NCKS$//;
         next unless $name =~ m/Cp$/ or $name =~ m/Np$/ or $name =~ m/Nx$/
-            or $name =~ m/slv$/ or $name =~ m/p42$/;
+            or $name =~ m/slv$/ or $name =~ m/p42$/
+	    or $name =~ m/p48$/ or $name =~ m/v72$/
+	    or $name =~ m/z17$/ or $name =~ m/v73$/;
         push @new, $name;
     }
     @topList = @new;

--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -887,6 +887,7 @@ sub defaults {
                      OBS_GridComp.rc.tmpl
                      saverst.rc 
                      GEOS_SurfaceGridComp.rc
+		     GEOS_IgniGridComp.rc
                      logging.yaml );
 
   @coupled_files = qw( data_table

--- a/src/Applications/GEOSdas_App/write_monthly_rc_arc.pl
+++ b/src/Applications/GEOSdas_App/write_monthly_rc_arc.pl
@@ -321,7 +321,9 @@ sub means_type {
 sub plots_type {
     my $name = shift;
     return unless means_type($name);
-    return unless $name =~ m/Cp$/ or $name =~ m/Np$/ or $name =~ m/Nx$/;
+#    return unless $name =~ m/Cp$/ or $name =~ m/Np$/ or $name =~ m/Nx$/;
+    return unless $name =~ m/Cp$/ or $name =~ m/Np$/ or $name =~ m/Nx$/
+	    or $name =~ m/p48$/ or $name =~ m/glo_L/;
     return 1;
 }
 

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/setup_atmens.pl
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/setup_atmens.pl
@@ -246,7 +246,12 @@ sub init {
          $obsv_nx =    4; $obsv_ny =    8;
          $stat_nx =    2; $stat_ny =    2;
      } elsif ($nodename eq "cas") {
-         die "Sorry this node/resolution not set yet, aborting \n";
+         $enkf_cpus = 368;
+         $agcm_nx =    6; $agcm_ny =   24;
+         $miau_nx =    2; $miau_ny =   12;
+         $obsv_nx =    4; $obsv_ny =   24;
+         $stat_nx =    2; $stat_ny =   24;
+#         die "Sorry this node/resolution not set yet, aborting \n";
 #        $agcm_ncpus_per_node = 46;
      } else {
          die "Unknown node name, aborting \n";


### PR DESCRIPTION
These updates are for the next ADAS tag for M21C/R21C. All updates are zero-diff for the GCM. Four components have been updated:
1. GEOSadas (see minor script changes below)
2. GEOSgcm_GridComp:
   * Bugfixes in MoistGC to allow budget to close. Added diagnostic W export.
   * Bugfix to avoid double-counting in Turb KE budget
   * Bugfix for OX tendency units
3. GEOSgcm_App
   * Bugfix for HISTORY description fields
   * Relax bit shaving in certain collections for better precision
5. GOCART
   * Changes in long_names to better describe fields