### PR TITLE
Update R21C to MAPL v2.35.3+R21C_v1.2.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -40,7 +40,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.35.3+R21C_v1.1.0
+  tag: v2.35.3+R21C_v1.2.0
   develop: R21C
 
 FMS:


### PR DESCRIPTION
This PR updates R21C to use MAPL v2.35.3+R21C_v1.2.0. This tag of MAPL has the ACG fixes needed by @acollow to clean up the long name handling in GOCART (see https://github.com/GEOS-ESM/GOCART/pull/278).

Note that this is required for https://github.com/GEOS-ESM/GOCART/pull/278 since it adds an option to the ACG that PR needs.