### PR TITLE
Try 2: Fix up the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2.1
 
 # Anchors to prevent forgetting to update a version
-baselibs_version: &baselibs_version v7.25.0
+baselibs_version: &baselibs_version v7.27.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@4
 
 workflows:
   build-test:

--- a/components.yaml
+++ b/components.yaml
@@ -41,7 +41,7 @@ GMAO_Shared:
 GMAOpyobs:
   local: ./src/Shared/@GMAO_Shared/@GMAO_pyobs
   remote: ../GMAOpyobs.git
-  tag: v1.0.6
+  branch: feature/mathomp4/allow-no-f2py-1.0.6
   develop: develop
 
 AeroML:


### PR DESCRIPTION
This is a new attempt to fix up the CI. I'm trying to use a change in GMAOpyobs to avoid `f2py` for now.

If this works, I'll work with the GMAOpyobs folks to get a v1.0.6.1 release out.