### PR TITLE
R21C: trigger o-server when running M21C

### DIFF
--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -388,7 +388,7 @@ my ($acqloc);
 my ($fcstimes,$fcswait_hrs,$asnwait_hrs);
 my ($landbcs);
 my ($coupled, $ores, $mometc);
-my ($o_servers,$bckend_wrts);
+my ($o_servers,$bckend_wrts, $xncpus, $ncpus_per_node);
 
 my ($sysfile, $nodeflg);
 my (@rmTilde);
@@ -3347,6 +3347,8 @@ EOF
   $nx = query("  Number of PEs in the zonal direction (NX)?", $nx);
   $ny = query("  Number of PEs in the meridional direction (NY)?", $ny);
   $ncpus = $nx * $ny;
+  my $this_many_nodes = ceil($ncpus/$ncpus_per_node) + $o_servers;
+  $xncpus = $this_many_nodes * $ncpus_per_node;
 
   $jobn = query("  Job nickname?", $jobn);
   $jobn = substr($jobn,0,5);
@@ -3663,10 +3665,10 @@ EOF
       $nxgsi = query("  Number of procs in the zonal direction (NX)?", $nxDEF);
       $nygsi = query("  Number of procs in the meridional direction (NY)?", $nyDEF);
       $ncpus_gsi = $nxgsi * $nygsi;
-      last if $ncpus_gsi <= $ncpus;
+      last if $ncpus_gsi <= $xncpus;
 
       print "\n  >>> WARNING <<<"
-          . "\n  GSI CPUs ($ncpus_gsi) exceeds total number of CPUs ($ncpus)\n";
+          . "\n  GSI CPUs ($ncpus_gsi) exceeds total number of CPUs ($xncpus)\n";
       die ">>> ERROR <<< too many unsuccessful attempts;" if ++$cnt > 3;
       print "  Try again.\n\n";
   }
@@ -7790,9 +7792,6 @@ if ( $fvchem && $lm > 2 ) {
  }
  $pi = $i;       # p for PSAS
 
- my $this_many_nodes = ceil($ncpus/$ncpus_per_node) + $o_servers;
- my $xncpus = $this_many_nodes * $ncpus_per_node;
-
 # Turn off some parallelization on discover
 #------------------------------------------
  if ( ($siteID eq "nccs") || ($siteID eq "nas") ) {
@@ -8994,8 +8993,6 @@ sub create_fscript {
 
  open(SCRIPT,">$fvhome/fcst/$jobf.j") or
  die ">>> ERROR <<< cannot write $fvhome/fcst/$jobf.j";
-
- my $xncpus = $ncpus + $o_servers * $ncpus_per_node;
 
  print  SCRIPT <<"EOF";
 #!/bin/csh -fx

--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -351,6 +351,7 @@ use File::Path qw(mkpath rmtree);
 use Getopt::Long qw(GetOptions);
 use Sys::Hostname;
 use Time::Local;         # time functions
+use POSIX qw(ceil);
 
 use FindBin;             # so we can find where this script resides
 use lib ("$FindBin::Bin", "$ESMADIR/$ARCH/bin");
@@ -3232,8 +3233,8 @@ sub get_times {
 #                                                    #       ----
       if    ($res eq "C48")  { $nx =  4; $ny = 24 }  # (b)    96
       elsif ($res eq "C90")  { $nx =  4; $ny = 24 }  # (c)    96
-      elsif ($res eq "C180") { $nx = 15; $ny = 36 }  # (d)   360
-      elsif ($res eq "C360") { $nx =  8; $ny = 48 }  # (e)   384
+      elsif ($res eq "C180") { $nx =  9; $ny = 30 }  # (d)   270
+      elsif ($res eq "C360") { $nx = 10; $ny = 36 }  # (e)   360
       else                   { $nx = 28; $ny = 48 }  # (f+) 1344
   }
   else {
@@ -4872,7 +4873,6 @@ EOF
   $use_shmem = 0;
   $o_servers = 0;
   $bckend_wrts = 0;
-  $ios_nds = 1;
   $cldmicro = "1MOMENT";
   if ( "$res" eq "c" && "$vres" eq "55" ) {
        $anahgrd = substr($res,0,1);
@@ -5167,7 +5167,6 @@ EOF
           $bckend_wrts = 24;
        }
        $cubed = 1;
-#      $ios_nds = 2;
        $specres = "254";
        $jcap = "254";
        $agcm_grid_type = "Cubed-Sphere";
@@ -5201,8 +5200,11 @@ EOF
        $ana_im_ens = 288;
        $ana_jm_ens = 181;
   } elsif ( "$res" eq "C360" ) {  # Cubed-sphere
+       if ($r21c) {
+          $o_servers = 3;
+          $bckend_wrts = 24;
+       }
        $cubed = 1;
-#      $ios_nds = 2;
        $specres = "254";
        $jcap = "254";
        $agcm_grid_type = "Cubed-Sphere";
@@ -5276,7 +5278,6 @@ EOF
   } elsif ( "$res" eq "C1440" ) {  # Cubed-sphere
        $cubed = 1;
        $o_servers = 8;
-#      $ios_nds = 4;
        $specres = "254";
        $jcap = "254";
        $agcm_grid_type = "Cubed-Sphere";
@@ -7789,7 +7790,8 @@ if ( $fvchem && $lm > 2 ) {
  }
  $pi = $i;       # p for PSAS
 
- my $xncpus = $ncpus + $o_servers * $ncpus_per_node;
+ my $this_many_nodes = ceil($ncpus/$ncpus_per_node) + $o_servers;
+ my $xncpus = $this_many_nodes * $ncpus_per_node;
 
 # Turn off some parallelization on discover
 #------------------------------------------
@@ -9887,7 +9889,11 @@ sub init_agcm_rc {
     AGCM_label_subst("\@GRID_TYPE", $agcm_grid_type);
     AGCM_label_subst("\@CUBE_AGCM", $cube_agcm);
     AGCM_label_subst("\@LATLON_AGCM", $latlon_agcm);
-    AGCM_label_subst("\@NUM_OSERVER_NODES", $ios_nds);
+    if ( $o_servers > 0 ) {
+       AGCM_label_subst("\@NUM_OSERVER_NODES", $o_servers);
+    } else {
+       AGCM_label_subst("\@NUM_OSERVER_NODES", 1);
+    }
     AGCM_label_subst("\@NUM_BACKEND_PES", $bckend_wrts);
 
     AGCM_label_subst("\@AANA_IM", $ana_im);

--- a/src/Applications/GEOSdas_App/testsuites/m21c_j98RPY.input
+++ b/src/Applications/GEOSdas_App/testsuites/m21c_j98RPY.input
@@ -1,9 +1,9 @@
 #---------------
-# m21c_j98.input
+# m21c_j98RPY.input
 #---------------
 
 codeID: 271edc7
-description: m21c_j98__agrid_C360__ogrid_CS
+description: m21c_j98RPY__agrid_C360__ogrid_CS
 fvsetupID: 
 
 ---ENDHEADERS---
@@ -29,7 +29,7 @@ EXPID? [u000_C360]
 Check for previous use of expid (y/n)? [y]
 > n
 
-EXPDSC? [m21c_j98__agrid_C360__ogrid_CS]
+EXPDSC? [m21c_j98RPY__agrid_C360__ogrid_CS]
 > 
 
 Land Boundary Conditions? [Icarus-NLv3]
@@ -38,10 +38,10 @@ Land Boundary Conditions? [Icarus-NLv3]
 Catchment Model choice? [1]
 > 
 
-FVHOME? [/discover/nobackup/rtodling/m21c_j98]
+FVHOME? [/discover/nobackup/rtodling/m21c_j98RPY]
 > /discover/nobackup/projects/gmao/dadev/rtodling/M21C/$expid
 
-The directory /discover/nobackup/projects/gmao/dadev/rtodling/M21C/m21c_j98 does not exist. Create it now? [y]
+The directory /discover/nobackup/projects/gmao/dadev/rtodling/M21C/m21c_j98RPY does not exist. Create it now? [y]
 > 
 
 Processing nodes (1:Haswell, 2:Skylake, 3:Cascase, 4:Milan)? [3]
@@ -212,26 +212,14 @@ Output Restart TYPE (bin or nc4) [nc4]
 Select group: [g2538]
 > g0613
 
-Replayed Ensemble?  [no]
-> 
+Replayed Ensemble (from OPS)?  [no]
+> yes
 
-Use SPPT-scheme for Ensemble?  [yes]
-> 
+Replay exp name? [x0046d]
+> e5303_m21c_jan98
 
-Use Precip Correction for Ensemble?  [yes]
-> 
-
-Ensemble Resolution?  [C90]
-> 
-
-Ensemble Vertical Levels?  [72]
-> 
-
-Experiment archive directory for ensemble restarts or 'later': [/archive/u/rtodling/m21c_j98]
+Replay archive directory? [/discover/nobackup/projects/gmao/dadev/rtodling/archive/x0046d]
 > /gpfsm/dnb08/projects/p253/archive/e5303_m21c_jan98
-
-Continue without missing resource files? [y]
-> 
 
 Edit COLLECTIONS list in run/HISTORY.rc.tmpl (y/n)? [n]
 > 

--- a/src/Applications/GEOSdas_App/testsuites/x0048.input
+++ b/src/Applications/GEOSdas_App/testsuites/x0048.input
@@ -44,8 +44,8 @@ FVHOME? [/discover/nobackup/dao_it/x0048]
 The directory /discover/nobackup/projects/gmao/obsdev/dao_it/x0048 already exists. Clean it? [y]
 > 
 
-Processing nodes (1:Westmere, 2:SandyBridge, 3:Ivy Bridge, 4:Haswell, 5:Skylake, 6:Cascase)? [4]
-> 5
+Processing nodes (1:Haswell, 2:Skylake, 3:Cascase, 4:Milan)? [4]
+> 2
 
 Which case of variational analysis? [1]
 > 

--- a/src/Applications/GEOSdas_App/testsuites/x0048RPY.input
+++ b/src/Applications/GEOSdas_App/testsuites/x0048RPY.input
@@ -44,8 +44,8 @@ FVHOME? [/discover/nobackup/dao_it/x0048RPY]
 The directory /discover/nobackup/projects/gmao/obsdev/dao_it/x0048RPY already exists. Clean it? [y]
 > 
 
-Processing nodes (1:Westmere, 2:SandyBridge, 3:Ivy Bridge, 4:Haswell, 5:Skylake, 6:Cascase)? [4]
-> 
+Processing nodes (1:Haswell, 2:Skylake, 3:Cascase, 4:Milan)? [4]
+> 2
 
 Which case of variational analysis? [1]
 > 


### PR DESCRIPTION
This now triggers the use of the O-SERVER machinery in the model/MAPL to run M21C. I have also added an input file for users interested in replaying to M21C - this is an example and as with any input file it will have to be mildly changed to fit the uses specifics.