### PR TITLE
Update GMAO_Shared version

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -35,7 +35,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: g5.41.3
+  tag: g5.41.4
   develop: main
 
 GMAOpyobs:


### PR DESCRIPTION
This reflects a change in GMAO_Shared that moves the acquire_obs related programs to GMAO_perllib. 

The plan is for the next change to turn GMAO_perllib into a repo of its own so SWELL can tap on that.