### PR TITLE
Remove GMAO_perllib into its own repo

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -35,7 +35,8 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: g5.41.4
+  branch: feature/mathomp4/remove-perllib
+  sparse: ./config/GMAO_Shared.sparse
   develop: main
 
 GMAOpyobs:
@@ -55,6 +56,12 @@ GEOS_Util:
   local: ./src/Shared/@GMAO_Shared/@GEOS_Util
   remote: ../GEOS_Util.git
   tag: rt-2.0.8+pr73
+  develop: main
+
+GMAO_perllib:
+  local: ./src/Shared/@GMAO_Shared/@GMAO_perllib
+  remote: ../GMAO_perllib.git
+  branch: main
   develop: main
 
 MAPL:


### PR DESCRIPTION
This PR removes GMAO_perllib into its own repo.

Requires a new GMAO_Shared as well: https://github.com/GEOS-ESM/GMAO_Shared/pull/361