### PR TITLE
Remove Checkpoint RSTs before re/start of model

### DIFF
--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/gcm_ensemble.csh
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/gcm_ensemble.csh
@@ -329,6 +329,7 @@ if ( -d $ENSWORK/ensctrl ) then
       gcm_ensset_rc.csh $expid $nymdb $nhmsb $tfcst $nlons $nlats ensctrl
     
       cd $ENSWORK/ensctrl
+      /bin/rm *_checkpoint*$NCSUFFIX
 
       if( -e cap_restart ) /bin/rm cap_restart
       echo $nymdb $nhmsb > cap_restart
@@ -438,6 +439,7 @@ if(! -e .DONE_ENSFCST ) then
      if(! -e $ENSWORK/.DONE_MEM${memtag}_${MYNAME}.$yyyymmddhh ) then
 
         gcm_ensset_rc.csh $expid $nymdb $nhmsb $tfcst $nlons $nlats mem$memtag
+        /bin/rm *_checkpoint*$NCSUFFIX
 
         # Run ensemble
         # ------------


### PR DESCRIPTION
I am finding that many of the troubles w/ restarting the ensemble after a crash are associated w/ the presence of checkpoint restarts and the fact that MAPL does not allow for the overwrite of these files.

I am asking that MAPL adds an option  (in AGCM.rc) so users can allow for overwrite of restarts  - until then, the changes here make sure the checkpoint files are absent before model starts .... notice an option for overwriting or not history output was added a while back and is exercised in the ADAS; the troubles fixed here are of similar nature of when we were not allowed to overwrite the history output.