### PR TITLE
Updates for GEOSadas 5.29.5-p6 on SLES15

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSadas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.4.0.1
+  branch: feature/mathomp4/GEOSadas-5.29.5-SLES15
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.5.2
+  branch: feature/mathomp4/GEOSadas-5.29.5-SLES15
   develop: develop
 
 ecbuild:
@@ -28,7 +28,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.10.5-GEOS-FP-6
+  branch: feature/mathomp4/GEOSadas-5.29.5-SLES15
   develop: main
 
 GMAOpyobs:
@@ -140,7 +140,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.5.6.3
+  branch: feature/mathomp4/GEOSadas-5.29.5-SLES15
   develop: develop
 
 UMD_Etc:


### PR DESCRIPTION
This tracks changes needed for GEOSadas-5.29.5-p6 on SLES 15.

PRs in other repos (all on the `feature/mathomp4/GEOSadas-5.29.5-SLES15` branch):

* https://github.com/GEOS-ESM/ESMA_env/pull/149
* https://github.com/GEOS-ESM/ESMA_cmake/pull/421
* https://github.com/GEOS-ESM/GEOSgcm_App/pull/687
* https://github.com/GEOS-ESM/GMAO_Shared/pull/367

---

To build on Cas SLES15 you can do:

```
./parallel_build.csh -cas15
```