### PR TITLE
Fix DT for C720

### DIFF
--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -5201,7 +5201,7 @@ EOF
        $nx = 24;
        $ny = $nx * 6;
        $km = $vres;
-       $dt = 300;
+       $dt = 450;
        $long_dt  = $dt;
        $pert_dt = 900;
        $chemdt = $dt;


### PR DESCRIPTION
Somehow I accidentally took a change from gcm_setup not applicable for the current configuration of the model as used in FP (and ADAS).

Not zero diff for C720; zero-diff for all other configurations.