### PR TITLE
Changes to allow 'radcor' programs to work with enhanced 255-level raobs

### DIFF
--- a/src/Applications/NCEP_Paqc/radcor/m_RadBufr.f
+++ b/src/Applications/NCEP_Paqc/radcor/m_RadBufr.f
@@ -94,6 +94,9 @@
 !     28Dec2022  Meta       Add option to use environment variable to increase
 !                           the maximum BUFR record size
 !
+!     10Feb2025  Meta       Increase max level count to accommodate increased
+!                           number of sounding levels, increase maximum
+!                           BUFR record size
 !EOP
 !-----------------------------------------------------------------
 
@@ -105,7 +108,7 @@
      .   BKind        =  8,        ! Size of real
 c     .   ReasonCode   =  1,        ! Reason code for all corrected obs
      .   DeflReasonCode   =  100,      ! Reason code for all corrected obs
-     .   NLev_Max     =  255,      ! Max no. of levels in a buffer sounding
+     .   NLev_Max     =  512,      ! Max no. of levels in a buffer sounding
      .   Nks_Max      =  1000,     !        ... soundings (in first file scan)
      .   NPrepEvn_Max =  10        !        ... events in prep buffer file.
 

--- a/src/Applications/NCEP_Paqc/radcor/m_RadData.f
+++ b/src/Applications/NCEP_Paqc/radcor/m_RadData.f
@@ -156,6 +156,8 @@
 !                           and rkx_RS80_Marwin to module m_VaiUtil.
 !     20Mar2007  C. Redder  Initialized the components of all types to
 !                           0 or null.
+!     10Feb2025  Meta       Increase NLev_Def to accommodate increased
+!                           number of sounding levels
 !EOP
 !-----------------------------------------------------------------
       character (len=*), parameter :: MyModule = 'm_RadData'
@@ -170,7 +172,7 @@
      .   IMiss       = -10000,  ! ... and integer.
      .   nks_Def     =  1000,
      .   nkt_Def     =  10,
-     .   NLev_Def    =  255,
+     .   NLev_Def    =  512,
      .   NObs_Def    =  nks_Def * NLev_Def,
      .   LenID       =  8,
      .   NPresDigits =  5       ! Number of significant digits in pres obs


### PR DESCRIPTION
Recently NCEP modified the 'prepbufr' processing to include enhanced radiosonde profiles derived from high-density radiosonde data.  These soundings may have up to 255 wind and mass levels.  Tests with a sample file caused MERRA2 pre-processing to fail.  Increasing the maximum number of elements in sounding arrays to a larger number allowed the program to run.  Using 512 in place of 255 would handle things if 255 mass + 255 wind levels are needed.  Using an array dimensioned 512 in a call to read a BUFR field with dimension 255 is okay since the UFBINT call will return the number of elements used in the array.