### PR TITLE
update GEOS-IT to SLES15

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSadas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.4.0
+  branch: feature/rtodling/fp_5295_patch6
   develop: main
 
 cmake:
@@ -28,7 +28,26 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.10.5-GEOS-FP-2
+  branch: feature/rtodling/fp_5295_patch6
+  develop: main
+
+GMAOpyobs:
+  local: ./src/Shared/@GMAO_Shared/@GMAO_pyobs
+  remote: ../GMAOpyobs.git
+  tag: v1.0.6
+  develop: develop
+
+AeroML:
+  local: ./src/Shared/@AeroML
+  remote: ../AeroML.git
+  tag: feature/rtodling/abs2obs/cak_tag0
+  develop: develop
+  sparse: ./config/AeroML.sparse
+
+GEOS_Util:
+  local: ./src/Shared/@GMAO_Shared/@GEOS_Util
+  remote: ../GEOS_Util.git
+  tag: v2.0.7
   develop: main
 
 MAPL:

--- a/components.yaml
+++ b/components.yaml
@@ -65,7 +65,7 @@ FMS:
 GEOSana_GridComp:
   local: ./src/Components/@GEOSana_GridComp
   remote: ../GEOSana_GridComp.git
-  tag: v1.5.4.8-GEOS-FP-2
+  branch: feature/rtodling/fp_5295_patch6
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -28,7 +28,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.10.5-GEOS-FP-1
+  tag: v1.4.10.5-GEOS-FP-2
   develop: main
 
 MAPL:
@@ -46,7 +46,7 @@ FMS:
 GEOSana_GridComp:
   local: ./src/Components/@GEOSana_GridComp
   remote: ../GEOSana_GridComp.git
-  tag: v1.5.4.8-GEOS-FP-1
+  tag: v1.5.4.8-GEOS-FP-2
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ GEOSadas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  branch: feature/rtodling/fp_5295_patch6
+  tag: v3.4.0.1
   develop: main
 
 cmake:
@@ -28,7 +28,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  branch: feature/rtodling/fp_5295_patch6
+  tag: v1.4.10.5-GEOS-FP-6
   develop: main
 
 GMAOpyobs:
@@ -40,7 +40,7 @@ GMAOpyobs:
 AeroML:
   local: ./src/Shared/@AeroML
   remote: ../AeroML.git
-  tag: feature/rtodling/abs2obs/cak_tag0
+  tag: g5.29.5-GEOS-FP-6
   develop: develop
   sparse: ./config/AeroML.sparse
 
@@ -53,7 +53,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  branch: feature/mathomp4/update-mapl-2.8.0-to-python3
+  tag: v2.8.0.10
   develop: develop
 
 FMS:
@@ -65,7 +65,7 @@ FMS:
 GEOSana_GridComp:
   local: ./src/Components/@GEOSana_GridComp
   remote: ../GEOSana_GridComp.git
-  branch: feature/rtodling/fp_5295_patch6
+  tag: v1.5.4.8-GEOS-FP-6
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -53,7 +53,7 @@ GEOS_Util:
 MAPL:
   local: ./src/Shared/@MAPL
   remote: ../MAPL.git
-  tag: v2.8.0.9
+  branch: feature/mathomp4/update-mapl-2.8.0-to-python3
   develop: develop
 
 FMS:

--- a/components.yaml
+++ b/components.yaml
@@ -28,7 +28,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.10.5
+  tag: v1.4.10.5-GEOS-FP-1
   develop: main
 
 MAPL:
@@ -46,7 +46,7 @@ FMS:
 GEOSana_GridComp:
   local: ./src/Components/@GEOSana_GridComp
   remote: ../GEOSana_GridComp.git
-  tag: v1.5.4.8
+  tag: v1.5.4.8-GEOS-FP-1
   develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSadas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  tag: v3.4.0.1
+  branch: feature/mathomp4/GEOSadas-5.29.5-SLES15
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  tag: v3.5.2
+  branch: feature/mathomp4/GEOSadas-5.29.5-SLES15
   develop: develop
 
 ecbuild:
@@ -28,7 +28,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.4.10.5-GEOS-FP-6
+  branch: feature/rtodling/g5_29_5p6_sles15
   develop: main
 
 GMAOpyobs:
@@ -65,7 +65,7 @@ FMS:
 GEOSana_GridComp:
   local: ./src/Components/@GEOSana_GridComp
   remote: ../GEOSana_GridComp.git
-  tag: v1.5.4.8-GEOS-FP-6
+  branch: feature/rtodling/g5_29_5p6_sles15
   develop: develop
 
 GEOSgcm_GridComp:
@@ -140,7 +140,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.5.6.3
+  branch: feature/rtodling/g5_29_5p6_sles15
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -65,7 +65,7 @@ FMS:
 GEOSana_GridComp:
   local: ./src/Components/@GEOSana_GridComp
   remote: ../GEOSana_GridComp.git
-  branch: feature/rtodling/g5_29_5p6_sles15
+  branch: feature/rtodling/geosit_v1.5.4.7_plus
   develop: develop
 
 GEOSgcm_GridComp:
@@ -140,7 +140,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  branch: feature/rtodling/g5_29_5p6_sles15
+  branch: bugfix/rtodling/geosit_donot_mergeWfp
   develop: develop
 
 UMD_Etc:

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ GEOSadas:
 env:
   local: ./@env
   remote: ../ESMA_env.git
-  branch: feature/mathomp4/GEOSadas-5.29.5-SLES15
+  tag: g3.4.0.2
   develop: main
 
 cmake:
   local: ./@cmake
   remote: ../ESMA_cmake.git
-  branch: feature/mathomp4/GEOSadas-5.29.5-SLES15
+  tag: g3.5.2.1
   develop: develop
 
 ecbuild:
@@ -28,7 +28,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  branch: feature/rtodling/g5_29_5p6_sles15
+  tag: v1.4.10.5-GEOS-FP-6-SLES15
   develop: main
 
 GMAOpyobs:
@@ -65,7 +65,7 @@ FMS:
 GEOSana_GridComp:
   local: ./src/Components/@GEOSana_GridComp
   remote: ../GEOSana_GridComp.git
-  branch: feature/rtodling/geosit_v1.5.4.7_plus
+  tag: g1.5.4.7-IT-sync-1
   develop: develop
 
 GEOSgcm_GridComp:
@@ -140,7 +140,7 @@ mom6:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  branch: bugfix/rtodling/geosit_donot_mergeWfp
+  tag: g1.5.6.3-GEOS-IT-1
   develop: develop
 
 UMD_Etc:

--- a/config/AeroML.sparse
+++ b/config/AeroML.sparse
@@ -1,0 +1,5 @@
+/*
+!/src/eNNR
+!/src/NNR
+!/src/Shared
+!/Cmakelists.txt

--- a/src/Applications/GAAS_App/aeronet_all.py
+++ b/src/Applications/GAAS_App/aeronet_all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Splits AERONET into synoptic chunks.
 """
@@ -17,7 +17,7 @@ def makethis_dir(path):
     if path != '':
         rc = os.system('mkdir -p '+path)
         if rc:
-            raise IOError, "could not create directory "+path
+            raise IOError("could not create directory "+path)
 
 if __name__ == "__main__":
 
@@ -28,8 +28,8 @@ if __name__ == "__main__":
     onehour = timedelta(seconds=60*60)
         
     if len(sys.argv)<2:
-        print "Usage:"
-        print "        aeronet4_all.py  year1 [year2]"
+        print("Usage:")
+        print("        aeronet4_all.py  year1 [year2]")
         sys.exit(1)
     else:
         y1 = sys.argv[1]
@@ -37,7 +37,7 @@ if __name__ == "__main__":
             y2 = sys.argv[2]
         else:
             y2 = y1
-        Years = range(int(y1),int(y2)+1)
+        Years = list(range(int(y1),int(y2)+1))
             
     # Loop over years
     # ---------------
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
             today = tyme0 + (doy-1) * oneday
 
-            print 'Day: ', today
+            print('Day: ', today)
 
             # Read AERONET for this day
             # -------------------------

--- a/src/Applications/GAAS_App/ana_aod.j.tmpl
+++ b/src/Applications/GAAS_App/ana_aod.j.tmpl
@@ -42,7 +42,7 @@ setenv nymd           >>>NYMD<<<
 cd $AODWORK
 ls
 
-setenv PYTHONPATH $FVROOT/lib/Python
+setenv PYTHONPATH $FVROOT/lib/Python:$FVROOT/lib/Python/pyobs:$FVROOT/lib/Python/pyods
 setenv PSAS_NUM_MPI 1 # $NCPUS_AOD
 
 set aod_modis_pcf = $AODWORK/modis_l2a.pcf

--- a/src/Applications/GAAS_App/aod_data.py
+++ b/src/Applications/GAAS_App/aod_data.py
@@ -1,14 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os, sys
 
 def aod_type(dataID, stdoutFLG=True):
     """
+    input_parameters
+     => dataID: label used to identify data set in the obsys_rc file
+     => stdoutFLG: set to False, if calling directly from Python code
+
     purpose
     Identify AOD data type
-
-    input parameters
-     => dataID: label used to identify data set in the obsys_rc file
-     => stdoutFLG: if True, then print result to STDOUT before returning it
 
     return value
      => aod_type_val: AOD data type
@@ -49,12 +49,13 @@ def aod_type(dataID, stdoutFLG=True):
 #.......................................................................
 def aod_filter(classlist_string, stdoutFLG=True):
     """
-    purpose: remove excess AOD data sets from obsclass list.
+    input_parameters
+     => classlist_string: AOD obsclass list (separated by commas, no spaces)
+     => stdoutFLG: set to False, if calling directly from Python code
 
-    input parameters
-     => classlist_string: AOD obsclass list (string with labels separated by
-                          commas, no spaces)
-     => stdoutFLG: if True, then print result to STDOUT before returning it
+    purpose: remove duplicate AOD data sets from obsclass list
+
+    NOTE: THIS ROUTINE DOES NOT CHECK DATA AVAILABILITY
 
     return value
      => newlist_string: filtered obsclass list string
@@ -114,8 +115,8 @@ if __name__ == "__main__":
 
     if len(sys.argv) < 2:
         scriptname = os.path.basename(sys.argv[0])
-        print("\n    usage: {0} routineName routineParams".format(scriptname))
-        print( "     routineName options = {0}\n".format(routineList.keys()))
+        print(("\n    usage: {0} routineName routineParams".format(scriptname)))
+        print(( "     routineName options = {0}\n".format(routineList.keys())))
         exit()
 
     routineName = sys.argv[1]

--- a/src/Applications/GAAS_App/aod_util.F90
+++ b/src/Applications/GAAS_App/aod_util.F90
@@ -41,6 +41,8 @@
 !  12nov1999 da Silva First crack.
 !  12sep2016 Todling  Replaced peanut extinctions with total extinction.
 !  01oct2016 Todling  Backward-compatible read for extinctions.
+!  01Dec2022 Todling  - Read tau as rank-3 array;
+!                     - Add DREXTAU and NIEXTAU to case when total not found
 !
 !EOP
 !--------------------------------------------------------------------------
@@ -538,7 +540,7 @@ subroutine AOD_GetTau1ch ( filename, im, jm, km, nymd, nhms, verbose, w_tau, rc 
 !                               ---
   type(Chem_Registry) :: aodReg
   integer             :: n, fid, incSecs
-  real                :: tau(im,jm)
+  real                :: tau(im,jm,1)
 
   integer :: nch = 1
   real :: channels(1) = (/ 550. /) ! this is hardwired for hyperwall files
@@ -603,11 +605,11 @@ subroutine AOD_GetTau1ch ( filename, im, jm, km, nymd, nhms, verbose, w_tau, rc 
 ! read tau for individual species and sum them up
 ! -----------------------------------------------
   do n = 1, nq
-     call GFIO_GetVar ( fid, vname(n), nymd, nhms, im, jm, 0, 1, tau, rc )
+     call GFIO_GetVar ( fid, vname(n), nymd, nhms, im, jm, 1, 1, tau, rc )
      if ( rc == 0 ) then
         if (verbose) &
              print *, '[+] Adding '//trim(vname(n))//' contribution at ', nymd, nhms
-        w_tau%qa(1)%data3d(:,:,1) = w_tau%qa(1)%data3d(:,:,1) + tau
+        w_tau%qa(1)%data3d(:,:,1) = w_tau%qa(1)%data3d(:,:,1) + tau(:,:,1)
      else
         print *, 'warning cannot read hyperwall variable ', vname(n)
         print *, 'will try reading old wired-in specifies ...'
@@ -619,14 +621,14 @@ subroutine AOD_GetTau1ch ( filename, im, jm, km, nymd, nhms, verbose, w_tau, rc 
   if ( rc/=0 ) then
      rc=0 ! reset error code
      do n = 1, nqori
-        call GFIO_GetVar ( fid, vname_ori(n), nymd, nhms, im, jm, 0, 1, tau, rc )
+        call GFIO_GetVar ( fid, vname_ori(n), nymd, nhms, im, jm, 1, 1, tau, rc )
         if ( rc /= 0 ) then
            print *, 'warning cannot read hyperwall variable ', vname_ori(n)
            return
         end if
         if (verbose) &
              print *, '[+] Adding '//trim(vname(n))//' contribution at ', nymd, nhms
-        w_tau%qa(1)%data3d(:,:,1) = w_tau%qa(1)%data3d(:,:,1) + tau
+        w_tau%qa(1)%data3d(:,:,1) = w_tau%qa(1)%data3d(:,:,1) + tau(:,:,1)
      end do
   endif
 

--- a/src/Applications/GAAS_App/avhrr_all.py
+++ b/src/Applications/GAAS_App/avhrr_all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Splits AVHRR into synoptic chunks.
 """
@@ -14,8 +14,8 @@ if __name__ == "__main__":
     onehour = timedelta(seconds=60*60)
         
     if len(sys.argv)<2:
-        print "Usage:"
-        print "        avhrr_all.py  year1 [year2]"
+        print("Usage:")
+        print("        avhrr_all.py  year1 [year2]")
         sys.exit(1)
     else:
         y1 = sys.argv[1]
@@ -23,7 +23,7 @@ if __name__ == "__main__":
             y2 = sys.argv[2]
         else:
             y2 = y1
-        Years = range(int(y1),int(y2)+1)
+        Years = list(range(int(y1),int(y2)+1))
             
     # Loop over years
     # ---------------
@@ -42,5 +42,5 @@ if __name__ == "__main__":
 
                 cmd = 'python avhrr_l2a.py -v asc %d %d'%(nymd,nhms)
 
-                print cmd
+                print(cmd)
                 os.system(cmd)

--- a/src/Applications/GAAS_App/avhrr_l2a.py
+++ b/src/Applications/GAAS_App/avhrr_l2a.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -W ignore::DeprecationWarning
 
 """
@@ -54,10 +54,10 @@ if __name__ == "__main__":
     i = 0
     for orbit in cf('AVHRR_L2A_ORBITS').split(','):
         cmd = "patmosx_l2a.py %s %s %s %s"%(Options,orbit,nymd,nhms)
-        print cmd
+        print(cmd)
         if not options.dryrun:
             if system(cmd):
-                raise ValueError, "patmosx_l2a.py failed for %s on %s %s"%(orbit,nymd,nhms)
+                raise ValueError("patmosx_l2a.py failed for %s on %s %s"%(orbit,nymd,nhms))
 
         i += 1
     

--- a/src/Applications/GAAS_App/avhrr_nnr.py
+++ b/src/Applications/GAAS_App/avhrr_nnr.py
@@ -77,7 +77,7 @@ class AVHRR_NNR(avhrr.AVHRR_L2B):
         for inputName in self.net.InputNames:
 
             if self.verbose>0:
-                print 'Getting NN input ',inputName
+                print('Getting NN input ',inputName)
 
             # Retrieve input
             # --------------
@@ -114,7 +114,7 @@ class AVHRR_NNR(avhrr.AVHRR_L2B):
             return # no good data to work with
 
         if len(self.net.TargetNames)>1:
-            raise ValueError, 'Strange, more than one predictor'
+            raise ValueError('Strange, more than one predictor')
 
         # Evaluate NN on inputs
         # ---------------------
@@ -122,7 +122,7 @@ class AVHRR_NNR(avhrr.AVHRR_L2B):
 
         name = self.net.TargetNames[0]
         if self.verbose>0:
-            print "Evaluating NNR for <%s> with Log-AOD = "%name, self.net.laod 
+            print("Evaluating NNR for <%s> with Log-AOD = "%name, self.net.laod) 
 
         # Output is always AOD
         # --------------------

--- a/src/Applications/GAAS_App/misr_land.py
+++ b/src/Applications/GAAS_App/misr_land.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 
 Utility to read MISR ODS and write a smaller file with data only over land.
@@ -22,7 +22,7 @@ apath = '/nobackup/MODIS/Level3/ALBEDO/albedo_clim.ctl'
 if __name__ == "__main__":
 
     def blank(nymd,nhms):
-        print "    - NO DATA for %8d %6d "%(nymd, nhms)
+        print("    - NO DATA for %8d %6d "%(nymd, nhms))
         ods = ODS(nobs=1,kt=45,kx=313)
         ods.qcx[0] = 1
         ods.ks[0] = 1
@@ -38,7 +38,7 @@ if __name__ == "__main__":
             if os.path.isdir(item):      doDir(item)
             elif os.path.isfile(item):   doFile(item)
             else:
-                print "%s is not a valid file or directory, ignoring it"%item
+                print("%s is not a valid file or directory, ignoring it"%item)
 
     def doDir(dir):
         """Recursively, look for files in directory."""
@@ -47,13 +47,13 @@ if __name__ == "__main__":
             if os.path.isdir(path):      doDir(path)
             elif os.path.isfile(path):   doFile(path)
             else:
-                print "%s is not a valid file or directory, ignoring it"%item
+                print("%s is not a valid file or directory, ignoring it"%item)
 
 
     def doFile(fname):
 
         if fname.split('.')[-1] != 'ods':
-            print "[*] NOT ODS "+fname
+            print("[*] NOT ODS "+fname)
             return
 
         dirn = os.path.abspath(os.path.dirname(fname))
@@ -69,12 +69,12 @@ if __name__ == "__main__":
             landfn = landdn+'/'+basen.replace('aero_','aland_')
 
         if os.path.exists(landfn):
-            print "[ ] Skipping "+landfn
+            print("[ ] Skipping "+landfn)
             return
 
         os.system('/bin/mkdir -p '+landdn)
 
-        print "[x] Working on "+landfn
+        print("[x] Working on "+landfn)
 
         for nhms in range(0,240000,30000):
 
@@ -105,7 +105,7 @@ if __name__ == "__main__":
                         ods = blank(nymd,nhms)
 
                 if any(I):
-                    print "    + Processing %8d %6d with %5d obs left"%(nymd, nhms, len(v[I]))
+                    print("    + Processing %8d %6d with %5d obs left"%(nymd, nhms, len(v[I])))
 
             except:
                 ods = blank(nymd,nhms)
@@ -121,8 +121,8 @@ if __name__ == "__main__":
     #---
             
     if len(sys.argv) < 2 :
-        print 'Usage: '
-        print '        %s misr_ods_files/dir_names'%os.path.basename(sys.argv[0])
+        print('Usage: ')
+        print('        %s misr_ods_files/dir_names'%os.path.basename(sys.argv[0]))
         sys.exit(1)
 
     # Albedo dataset
@@ -131,7 +131,7 @@ if __name__ == "__main__":
         from grads import GrADS
         ga = GrADS(Echo=False,Window=False)
         fh = ga.open(apath)
-        print fh
+        print(fh)
 
     # Process list of files or directories
     # ------------------------------------

--- a/src/Applications/GAAS_App/modis_l2a.py
+++ b/src/Applications/GAAS_App/modis_l2a.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -W ignore::DeprecationWarning
 
 """
@@ -11,7 +11,7 @@
 
 from os       import system
 from optparse import OptionParser
-from MAPL     import Config
+from MAPL.config     import Config
 
 if __name__ == "__main__":
     
@@ -53,10 +53,10 @@ if __name__ == "__main__":
     for ident in cf('MODIS_L2A_IDENTS').split(','):
         coll = Coll[i] 
         cmd = "mxd04_l2a.py %s --collection=%s %s %s "%(Options,Coll[i],ident,isotime)
-        print cmd
+        print(cmd)
         if not options.dryrun:
             if system(cmd):
-                raise ValueError, "mxd04_l2a.py failed for %s on %s "%(ident,isotime)
+                raise ValueError("mxd04_l2a.py failed for %s on %s "%(ident,isotime))
 
         i += 1
     

--- a/src/Applications/GAAS_App/mxd04_l2a.py
+++ b/src/Applications/GAAS_App/mxd04_l2a.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -W ignore::DeprecationWarning
 
 """
@@ -21,11 +21,10 @@ import os
 import sys
 import subprocess
 
-from time            import clock
 from optparse        import OptionParser   # Command-line args  
 from dateutil.parser import parse as isoparse
 from mxd04_nnr       import MxD04_NNR
-from MAPL            import strTemplate
+from MAPL.config     import strTemplate
 
 Ident = dict( modo = ('MOD04','ocean'),
               modl = ('MOD04','land'),
@@ -42,7 +41,7 @@ def makethis_dir(filename):
     if path != '':
         rc = os.system('mkdir -p '+path)
         if rc:
-            raise IOError, "could not create directory "+path
+            raise IOError("could not create directory "+path)
         
 #---------------------------------------------------------------------
 
@@ -135,11 +134,10 @@ if __name__ == "__main__":
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
         
     if options.verbose:
-        print ""
-        print "                          MODIS Level 2A Processing"
-        print "                          -------------------------"
-        print ""
-        t0 = clock()
+        print("")
+        print("                          MODIS Level 2A Processing")
+        print("                          -------------------------")
+        print("")
 
 #   Time variables
 #   --------------
@@ -154,8 +152,8 @@ if __name__ == "__main__":
     out_file = strTemplate(out_tmpl,expid=options.expid,nymd=nymd,nhms=nhms)
     name, ext = os.path.splitext(out_file)
     if os.path.exists(out_file) and (options.force is not True):
-        print "mxd04_l2a: Output Gridded file <%s> exists --- cannot proceed."%out_file
-        raise IOError, "Specify --force to overwrite existing output file."    
+        print("mxd04_l2a: Output Gridded file <%s> exists --- cannot proceed."%out_file)
+        raise IOError("Specify --force to overwrite existing output file.")    
     if os.path.exists(out_file) and options.force:
         os.remove(out_file)    
 
@@ -165,8 +163,8 @@ if __name__ == "__main__":
     ods_tmpl = ods_tmpl.replace('%coll',options.coll).replace('%prod',prod).replace('%algo',algo).replace('%lev','2').replace('%ext','ods')
     ods_file = strTemplate(ods_tmpl,expid=options.expid,nymd=nymd,nhms=nhms)
     if os.path.exists(ods_file) and (options.force is not True):
-        print "mxd04_l2a: Output ODS file <%s> exists --- cannot proceed."%ods_file
-        raise IOError, "Specify --force to overwrite existing output file."
+        print("mxd04_l2a: Output ODS file <%s> exists --- cannot proceed."%ods_file)
+        raise IOError("Specify --force to overwrite existing output file.")
     if os.path.exists(ods_file) and options.force:
         os.remove(ods_file)
 
@@ -181,7 +179,7 @@ if __name__ == "__main__":
 #   MODIS Level 2 NNR Aerosol Retrievals
 #   ------------------------------------
     if options.verbose:
-        print "NNR Retrieving %s %s on "%(prod,algo.upper()),syn_time
+        print("NNR Retrieving %s %s on "%(prod,algo.upper()),syn_time)
 
     modis = MxD04_NNR(options.l2_path,prod,algo.upper(),syn_time,aer_x,
                       coll=options.coll,
@@ -191,11 +189,11 @@ if __name__ == "__main__":
                       verbose=options.verbose)
     if modis.nobs < 1:
         if options.verbose:
-            print 'WARNING: no observation for this time in file <%s>'%ods_file
+            print('WARNING: no observation for this time in file <%s>'%ods_file)
     
     elif any(modis.iGood) == False:
         if options.verbose:
-            print 'WARNING: no GOOD observation for this time in file <%s>'%ods_file
+            print('WARNING: no GOOD observation for this time in file <%s>'%ods_file)
         modis.nobs = 0
 
     nn_file = options.nn_file.replace('%ident',ident)
@@ -211,7 +209,7 @@ if __name__ == "__main__":
             warnings.warn('cannot create empty output file <%s>'%ods_file)
         else:
             if options.verbose:
-                print "[w] Wrote empty ODS file "+ods_file
+                print("[w] Wrote empty ODS file "+ods_file)
 
 #   Write gridded output file (revised channels only)
 #   -------------------------------------------------

--- a/src/Applications/GAAS_App/mxd04_nnr.py
+++ b/src/Applications/GAAS_App/mxd04_nnr.py
@@ -204,7 +204,7 @@ class MxD04_NNR(MxD04_L2):
                 elif rank == 2:
                     self.__dict__[sds] = self.__dict__[sds][m,:]
                 else:
-                    raise IndexError, 'invalid rank=%d'%rank
+                    raise IndexError('invalid rank=%d'%rank)
 
             # Reset aliases
             for sds in self.SDS:
@@ -245,7 +245,7 @@ class MxD04_NNR(MxD04_L2):
             self.iGood = self.iGood & (self.ScatteringAngle < scat_thresh)
 
         if any(self.iGood) == False:
-            print "WARNING: Strange, no good obs left to work with"
+            print("WARNING: Strange, no good obs left to work with")
             return
 
         # Create attribute for holding NNR predicted AOD
@@ -304,6 +304,14 @@ class MxD04_NNR(MxD04_L2):
         except:
             pass   # ignore it for systems without nitrates
 
+        # Special handle for brown carbon (treat it as it were organic carbon)
+        # ----------------------------------------------------
+        try:
+            self.sampleFile(aer_x,onlyVars=('BREXTTAU',),Verbose=Verbose)
+            self.foc += self.sample.BREXTTAU / s.TOTEXTTAU
+            self.fcc = self.fbc + self.foc
+        except:
+            pass   # ignore it for systems without brown carbon as a separate tracer
         del self.sample
 
 #---
@@ -322,7 +330,7 @@ class MxD04_NNR(MxD04_L2):
           if fh.lm == 1:
             timeInterp = False    # no time interpolation in this case
           else:
-            raise ValueError, "cannot handle files with more tha 1 time, use ctl instead"
+            raise ValueError("cannot handle files with more tha 1 time, use ctl instead")
         else:
           fh = GFIOctl(inFile)  # open timeseries
           timeInterp = True     # perform time interpolation
@@ -341,7 +349,7 @@ class MxD04_NNR(MxD04_L2):
         # ---------------------------
         for v in onlyVars:
             if Verbose:
-                print "<> Sampling ", v
+                print("<> Sampling ", v)
             if timeInterp:
               var = fh.sample(v,lons,lats,tymes,Verbose=Verbose)
             else:
@@ -354,7 +362,7 @@ class MxD04_NNR(MxD04_L2):
                 var = var.T # shape should be (nobs,nz)
                 self.sample.__dict__[v] = var
             else:
-                raise IndexError, 'variable <%s> has rank = %d'%(v,len(var.shape))
+                raise IndexError('variable <%s> has rank = %d'%(v,len(var.shape)))
 
         if npzFile is not None:
             savez(npzFile,**self.sample.__dict__)            
@@ -381,7 +389,7 @@ class MxD04_NNR(MxD04_L2):
                 iName = inputName
 
             if self.verbose>0:
-                print 'Getting NN input ',iName
+                print('Getting NN input ',iName)
 
             # Retrieve input
             # --------------
@@ -402,7 +410,7 @@ class MxD04_NNR(MxD04_L2):
                 input = self.__dict__[name][:]
                 
             else:
-                raise ValueError, "strange, len(iName)=%d"%len(iName)
+                raise ValueError("strange, len(iName)=%d"%len(iName))
 
             # Concatenate Inputs
             # ------------------
@@ -457,9 +465,9 @@ class MxD04_NNR(MxD04_L2):
             name, ch = TranslateTarget[targetName]
             if self.verbose>0:
                 if self.net.laod:
-                    print "NN Retrieving log(AOD+0.01) at %dnm "%ch
+                    print("NN Retrieving log(AOD+0.01) at %dnm "%ch)
                 else:
-                    print "NN Retrieving AOD at %dnm "%ch
+                    print("NN Retrieving AOD at %dnm "%ch)
             k = list(self.channels).index(ch) # index of channel            
             self.channels_ = self.channels_ + [ch,]
             if self.net.laod:

--- a/src/Applications/GAAS_App/mxd04_nnr.py
+++ b/src/Applications/GAAS_App/mxd04_nnr.py
@@ -306,12 +306,12 @@ class MxD04_NNR(MxD04_L2):
 
         # Special handle for brown carbon (treat it as it were organic carbon)
         # ----------------------------------------------------
-        try:
-            self.sampleFile(aer_x,onlyVars=('BREXTTAU',),Verbose=Verbose)
-            self.foc += self.sample.BREXTTAU / s.TOTEXTTAU
-            self.fcc = self.fbc + self.foc
-        except:
-            pass   # ignore it for systems without brown carbon as a separate tracer
+#       try:
+#           self.sampleFile(aer_x,onlyVars=('BREXTTAU',),Verbose=Verbose)
+#           self.foc += self.sample.BREXTTAU / s.TOTEXTTAU
+#           self.fcc = self.fbc + self.foc
+#       except:
+#           pass   # ignore it for systems without brown carbon as a separate tracer
         del self.sample
 
 #---

--- a/src/Applications/GAAS_App/patmosx_l2a.py
+++ b/src/Applications/GAAS_App/patmosx_l2a.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -W ignore::DeprecationWarning
 
 """
@@ -37,13 +37,13 @@ def makethis_dir(filename):
     if path != '':
         rc = os.system('mkdir -p '+path)
         if rc:
-            raise IOError, "could not create directory "+path
+            raise IOError("could not create directory "+path)
 
 def patmosx_has_obs(fname):
     """
     Returns true if PATMOSX reflectance file has something in it.
     """
-    return 'latitude' in load(fname,allow_pickle=True).keys()
+    return 'latitude' in list(load(fname).keys())
 
 #---------------------------------------------------------------------
 
@@ -149,10 +149,10 @@ if __name__ == "__main__":
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
         
     if options.verbose:
-        print ""
-        print "                          AVHRR NNR Retrievals"
-        print "                          --------------------"
-        print ""
+        print("")
+        print("                          AVHRR NNR Retrievals")
+        print("                          --------------------")
+        print("")
         t0 = clock()
 
 #   Time variables
@@ -177,13 +177,13 @@ if __name__ == "__main__":
                         replace('%lev','2').replace('%ext','ods')
     ods_file = strTemplate(ods_tmpl,expid=options.expid,nymd=nymd,nhms=nhms)
     if os.path.exists(ods_file) and (options.force is not True):
-        print "avhrr_l3a: Output ODS file <%s> exists --- cannot proceed."%ods_file
-        raise IOError, "Specify --force to overwrite existing output file."
+        print("avhrr_l3a: Output ODS file <%s> exists --- cannot proceed."%ods_file)
+        raise IOError("Specify --force to overwrite existing output file.")
 
 #   Produce Level 2 AVHRR Aerosol Retrievals
 #   ----------------------------------------
     if options.verbose:
-        print "Retrieving AVHRR AOD from %s (%sing) on "%(prod,orb),syn_tyme
+        print("Retrieving AVHRR AOD from %s (%sing) on "%(prod,orb),syn_tyme)
 
     t = syn_tyme
     patmosx = options.l2_path+'/Y%d/M%02d/D%02d/%s.%s.%d%02d%02d_%02dz.npz'%\
@@ -202,12 +202,12 @@ if __name__ == "__main__":
         
     if a.nobs < 1:
         if options.verbose:
-            print 'WARNING: no observation for this time in file <%s>'%ods_file
+            print('WARNING: no observation for this time in file <%s>'%ods_file)
     
     # elif any(a.iValid) == False:
     elif len(a.tyme[a.iValid]) < 2:
         if options.verbose:
-            print 'WARNING: not enough GOOD observation for this time in file <%s>'%ods_file
+            print('WARNING: not enough GOOD observation for this time in file <%s>'%ods_file)
         a.nobs = 0
 
     else:
@@ -234,7 +234,7 @@ if __name__ == "__main__":
             warnings.warn('cannot create empty output file <%s>'%ods_file)
         else:
             if options.verbose:
-                print "[w] Wrote empty ODS file "+ods_file
+                print("[w] Wrote empty ODS file "+ods_file)
 
 #   Write gridded output file
 #   -------------------------

--- a/src/Applications/GEOSdas_App/Create_anasa_script.pm
+++ b/src/Applications/GEOSdas_App/Create_anasa_script.pm
@@ -77,6 +77,11 @@ sub anasa_script {
  open(SCRIPT,">$fvhome/anasa/$jobsa.j") or
  die ">>> ERROR <<< cannot write $fvhome/anasa/$jobsa.j";
 
+my $reservation = "";
+if ( $nodeflg eq "cas" ) {
+  $reservation = "SBATCH --reservation=sles15_cas";
+}
+
  print  SCRIPT <<"EOF";
 #!/bin/csh -fx
 #$group_list
@@ -87,6 +92,7 @@ sub anasa_script {
 #SBATCH --ntasks=$ncpus_gsi
 #SBATCH --ntasks-per-node=24
 #SBATCH --constraint=$nodeflg
+#$reservation
 #SBATCH --time=1:30:00
 #PBS -N anasa
 #PBS -o anasa.log.o%j

--- a/src/Applications/GEOSdas_App/Create_asens_script.pm
+++ b/src/Applications/GEOSdas_App/Create_asens_script.pm
@@ -80,6 +80,12 @@ sub asens_script {
  open(SCRIPT,">$fvhome/asens/$joba.j") or
  die ">>> ERROR <<< cannot write $fvhome/asens/$joba.j";
 
+my $reservation = "";
+if ( $nodeflg eq "cas" ) {
+  $reservation = "SBATCH --reservation=sles15_cas";
+}
+
+
  print  SCRIPT <<"EOF";
 #!/bin/csh -fx
 #$group_list
@@ -89,6 +95,7 @@ sub asens_script {
 #SBATCH --ntasks=$ncpus_gsi
 #SBATCH --ntasks-per-node=24
 #SBATCH --constraint=$nodeflg
+#$reservation
 #SBATCH --time=2:00:00
 #PBS -N asens
 #PBS -o asens.log.o%j.txt

--- a/src/Applications/GEOSdas_App/Create_fsens_script.pm
+++ b/src/Applications/GEOSdas_App/Create_fsens_script.pm
@@ -58,6 +58,11 @@ sub fsens_script {
  open(SCRIPT,">$fvhome/run/$jobfs.j") or
  die ">>> ERROR <<< cannot write $fvhome/run/$jobfs.j";
 
+my $reservation = "";
+if ( $nodeflg eq "cas" ) {
+  $reservation = "SBATCH --reservation=sles15_cas";
+}
+
  print  SCRIPT <<"EOF";
 #!/bin/csh -fx
 #$group_list
@@ -68,6 +73,7 @@ sub fsens_script {
 #SBATCH --ntasks=$ncpus_gsi
 #SBATCH --ntasks-per-node=24
 #SBATCH --constraint=$nodeflg
+#$reservation
 #SBATCH --time=${fcswallclk}:00
 #PBS -N fsens
 #PBS -o fsens.log.o%j

--- a/src/Applications/GEOSdas_App/edhist.pl
+++ b/src/Applications/GEOSdas_App/edhist.pl
@@ -355,7 +355,7 @@ sub parse_input {
 
         # (4) get collection fields
         #--------------------------
-        if ($look4fields and ($_ !~ m/\b(\S+)\.(\S+)\s*:(.*)$/)) {
+        if ($look4fields and (($_ !~ m/\b(\S+)\.(\S+)\s*:(.*)$/)| ($_ !~ m/\b(\S+)\.(\S+)(\S+)\.(\S+)\s*:(.*)$/)) ) {
             if ( (/[\'|\"]/) and (/\,/) ) {
                 $value = clean($_);
                 store($cname, $name, $traitN, $value);
@@ -1127,7 +1127,7 @@ sub plot_edit {
     foreach $name (@topList) {
         $name =~ s/_NCKS$//;
         next unless $name =~ m/Cp$/ or $name =~ m/Np$/ or $name =~ m/Nx$/
-            or $name =~ m/slv$/ or $name =~ m/p42$/;
+            or $name =~ m/slv$/ or $name =~ m/p42$/ or $name =~ m/v72$/ or $name =~ m/v73$/;
         push @new, $name;
     }
     @topList = @new;

--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -5108,15 +5108,15 @@ EOF
        $ana_jm_ens = 181;
   } elsif ( "$res" eq "C720" ) {  # Cubed-sphere
        $cubed = 1;
-       $o_servers = 8;
-       $bckend_wrts = 8;
+       $o_servers = 22;
+       $bckend_wrts = 22;
        $specres = "254";
        $jcap = "254";
        $agcm_grid_type = "Cubed-Sphere";
        $agcm_im  =  720;
        $agcm_jm  =  $agcm_im * 6;
-       $nx = 6;
-       $ny = $nx * 6;
+       $nx = 15;
+       $ny = 360;
        $km = $vres;
        $dt = 450;
        $pert_dt = 900;

--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -351,6 +351,7 @@ use File::Path qw(mkpath rmtree);
 use Getopt::Long qw(GetOptions);
 use Sys::Hostname;
 use Time::Local;         # time functions
+use POSIX qw(ceil);
 
 use FindBin;             # so we can find where this script resides
 use lib ("$FindBin::Bin", "$ESMADIR/$ARCH/bin");
@@ -7628,6 +7629,11 @@ print  SCRIPT <<"EOF";
 #SBATCH --constraint=$nodeflg
 #SBATCH --time=${daswallclk}:00
 EOF
+if ( $nodeflg eq "cas" ) {
+print  SCRIPT <<"EOF";
+#SBATCH --reservation=sles15_cas
+EOF
+}
 
 }else{
 
@@ -8813,6 +8819,11 @@ print  SCRIPT <<"EOF";
 #SBATCH --constraint=$nodeflg
 #SBATCH --time=${fcswallclk}:00
 EOF
+if ( $nodeflg eq "cas" ) {
+print  SCRIPT <<"EOF";
+#SBATCH --reservation=sles15_cas
+EOF
+}
 
 }else{
 
@@ -10714,7 +10725,7 @@ sub expand_EnvVars {
 
     # look for ${var} format
     #-----------------------
-    while ($string =~ m/(\${(\w+)})/)   {
+    while ($string =~ m/(\$[{(\w+)}])/)   {
         $var = $1; $name = $2;
         $var =~ s/\$/\\\$/;
         $string =~ s/$var/$ENV{$name}/;

--- a/src/Applications/GEOSdas_App/g5_ctl_seamless.py
+++ b/src/Applications/GEOSdas_App/g5_ctl_seamless.py
@@ -32,7 +32,7 @@ def main(opddir, verbose):
     collections = [x.split('/')[-1].replace('.latest','') for x in latestfiles]
     assert len(collections)>0
     if verbose:
-        print collections
+        print (collections)
 
     # if a corresponding ctl file exists in the 'assim/'
     # dir, we need a seamless ctl file for this collection
@@ -51,7 +51,7 @@ def main(opddir, verbose):
             continue
 
         if verbose: 
-            print '\nSeamless collection:', ctl_assim.split('/')[-1]
+            print ('\nSeamless collection:', ctl_assim.split('/')[-1])
 
         # get assim dset and tdef
         tdef_assim = None
@@ -66,7 +66,7 @@ def main(opddir, verbose):
         assert dset_assim
         nsteps_assim = int(tdef_assim.split()[1])
         if verbose:
-            print tdef_assim
+            print (tdef_assim)
 
         # we want seamless ctls for all fcast ctls including latest
         ctl_fcast_all = glob.glob(fcast_dir + '/' + clctnid + '/*')
@@ -88,7 +88,7 @@ def main(opddir, verbose):
             assert tdef_fcast
             assert dset_fcast
             if verbose:
-                print tdef_fcast
+                print (tdef_fcast)
             nsteps_fcast = int(tdef_fcast.split()[1])
 
             # for both assim and fcast tdefs, we expect
@@ -106,7 +106,7 @@ def main(opddir, verbose):
             tdef_seamless_splt[1] = str(nsteps_total)
             tdef_seamless = ' '.join(tdef_seamless_splt) + '\n'
             if verbose:
-                print tdef_seamless.strip()
+                print (tdef_seamless.strip())
 
             # dset for seamless ctl
             dset_base = dset_fcast.split('/forecast/')[0] + '/%ch\n'
@@ -116,7 +116,7 @@ def main(opddir, verbose):
             chsub2 = 'CHSUB %d %d %s\n' % (nsteps_assim+1, nsteps_total, ch_fcast)
             dset_seamless = dset_base + chsub1 + chsub2
             if verbose:
-                print dset_seamless
+                print (dset_seamless)
 
             # write seamless ctl with necessary changes
             # to dset and tdef

--- a/src/Applications/GEOSdas_App/monthly.yyyymm.pl.tmpl
+++ b/src/Applications/GEOSdas_App/monthly.yyyymm.pl.tmpl
@@ -56,7 +56,8 @@ use WriteLog qw(chdir_ mkpath_ unlink_ system_);
 # global variables
 #-----------------
 my ($meansFLG, $plotsFLG, $radmonFLG, $tarFLG, $finish, $nopush, %doMeans);
-my ($EXPID, $FVARCH, $FVHOME, $PBS_BIN, $PYRADMON, $account, $listdir);
+my ($EXPID, $FVARCH, $FVHOME, $NODEFLG, $PBS_BIN, $PYRADMON);
+my ($account, $listdir);
 my ($mnthlyRC, $numnodes_mm, $numnodes_mp, $plotHISTrc, $qcmd, $rundir);
 my ($script, $siteID, $workdir, $yyyymm, %newrc, %JOBID);
 my ($walltime_cl, $walltime_mm, $walltime_mp, $walltime_pf);
@@ -172,6 +173,7 @@ sub init {
     $PBS_BIN  = $ENV{"PBS_BIN"};
     $PYRADMON = $ENV{"PYRADMON"};
     $GID      = $ENV{"GID"};
+    $NODEFLG  = $ENV{"NODEFLG"};
     $datamove_constraint = $ENV{"datamove_constraint"};
     $datamove_constraint = "#";
     if ($datamove_constraint) {
@@ -487,7 +489,7 @@ sub fetch_inputs {
 sub calc_monthly_means {
     my (%opts, $filestring, $ftype, $htype, $do_dmput);
     my ($tmpl, $means_j, $jobname, $outfile, $tasks_per_node);
-    my ($job_name, $nodes, $time, $output, $per_node);
+    my ($job_name, $constraint, $nodes, $time, $output, $per_node);
     my ($vFLG, $processors, %value, @deps, $dependFLG, $cmd);
     my ($parFLG, $qosFLG);
 
@@ -515,6 +517,7 @@ sub calc_monthly_means {
         $job_name = "SBATCH --job-name=$jobname";
         $time = "SBATCH --time=$walltime_mm";
         $output = "SBATCH --output=$outfile";
+        $constraint = "SBATCH --constraint=$NODEFLG";
         $nodes = "SBATCH --nodes=$numnodes_mm";
         $per_node = "SBATCH --tasks-per-node=$tasks_per_node";
         $vFLG = "--export=outfile=$outfile";
@@ -537,6 +540,7 @@ sub calc_monthly_means {
     $value{"__ACCOUNT__"}    = $account;
     $value{"__OUTPUT__"}     = $output;
     $value{"__NODES__"}      = $nodes;
+    $value{"__CONSTRAINT__"} = $constraint;
     $value{"__PER_NODE__"}   = $per_node;
     $value{"__PROCESSORS__"} = $processors;
 
@@ -1023,7 +1027,7 @@ sub expand {
         $val_ENV  = $ENV{$varname};
         $val_eval = eval($var);
 
-        $var =~ s/([\$\{])/\\$1/;    # change '$' => '\$' and '{' => '\{'
+        $var =~ s/([\$\{\}])/\\$1/g;    # change '$'=>'\$', '{'=>'\{', '}'=>'\}'
 
         $strOUT =~ s/$var/$val_eval/ if defined($val_eval);
         $strOUT =~ s/$var/$val_ENV/  if defined($val_ENV);

--- a/src/Applications/GEOSdas_App/monthly_means.j.tmpl
+++ b/src/Applications/GEOSdas_App/monthly_means.j.tmpl
@@ -4,6 +4,7 @@
 #__TIME__
 #__ACCOUNT__
 #__OUTPUT__
+#__CONSTRAINT__
 #__MONTHLY_PARTITION__
 #__MONTHLY_QOS__
 #SBATCH --no-requeue

--- a/src/Applications/GEOSdas_App/monthly_setup.pl
+++ b/src/Applications/GEOSdas_App/monthly_setup.pl
@@ -186,6 +186,9 @@ sub write_plotfiles {
     $values{"\@GEOSBIN"} = "$FVROOT/bin";
     $values{"\@GEOSSRC"} = $ENV{"GEOSUTIL"};
 
+    $values{"\@MPT_SHEPHERD"} = "";
+    $values{"\@LD_LIBRARY_PATH_CMD"} = "LD_LIBRARY_PATH";
+
     $values{"\@BATCH_TIME"} = "SBATCH --time=";
     $values{"\@BATCH_JOBNAME"} = "SBATCH --job-name=";
     $values{"\@BATCH_OUTPUTNAMEOUTPUT"} = "SBATCH --output=OUTPUT";

--- a/src/Applications/GEOSdas_App/testsuites/runjob.pl
+++ b/src/Applications/GEOSdas_App/testsuites/runjob.pl
@@ -461,13 +461,13 @@ sub envsubst {
 
         # substitute for format $variable
         #--------------------------------
-        if ($string =~ m/(\$$var)/) {
+        if ($string =~ m/(\$[$var])/) {
             $string =~ s/\$$var/$ENV{$var}/g if $ENV{$var};
         }
 
         # substitute for format ${variable}
         #----------------------------------
-        if ($string =~ m/(\${$var})/) {
+        if ($string =~ m/(\$[$var])/) {
             $string =~ s/\${$var}/$ENV{$var}/g if $ENV{$var};
         }
     }

--- a/src/Applications/GEOSdas_App/write_monthly_rc_arc.pl
+++ b/src/Applications/GEOSdas_App/write_monthly_rc_arc.pl
@@ -321,7 +321,8 @@ sub means_type {
 sub plots_type {
     my $name = shift;
     return unless means_type($name);
-    return unless $name =~ m/Cp$/ or $name =~ m/Np$/ or $name =~ m/Nx$/;
+    return unless $name =~ m/Cp$/ or $name =~ m/Np$/ or $name =~ m/Nx$/ 
+               or $name =~ m/slv$/ or $name =~ m/p42$/;
     return 1;
 }
 
@@ -387,7 +388,7 @@ sub get_info_from_SILO {
     #---------------------------------------------------------------
     open SILO, "< $siloarc" or die "Error during open $siloarc;";
     while (<SILO>) {
-        next unless /\${PESTOROOT}/;
+        next unless /\$\{PESTOROOT\}/;
         next if /\+/;
 
         chomp($line = $_);
@@ -399,7 +400,7 @@ sub get_info_from_SILO {
 
             # modified line for $outRc file
             #------------------------------
-            ($mline1 = $mline) =~ s|\${PESTOROOT}\%s/||;
+            ($mline1 = $mline) =~ s|\$\{PESTOROOT\}\%s/||;
             $mline1 =~ s|%s|\${EXPID}|;
             next if $mline1 eq $mline;
 
@@ -430,7 +431,7 @@ sub get_info_from_SILO {
         foreach $mline (sort keys %tempOutRcHash) {
             if ($tempOutRcHash{$mline} eq $listflags) {
                 $name = "";
-                $name = $1 if $mline =~ /\${EXPID}\.(.*)\.%y/;
+                $name = $1 if $mline =~ /\$[{EXPID}]\.(.*)\.%y/;
 
                 $mline = "#".$mline if $listflags =~ m/C/;
                 ($flags = $listflags) =~ s/C//;

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/HISTAENS.rc.tmpl
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/HISTAENS.rc.tmpl
@@ -5,6 +5,7 @@
 #VERSION: 1
 EXPID:  >>>EXPID<<<
 EXPDSC: ensemble_bkg
+Allow_Overwrite: .true.
  
 GRID_LABELS: PC@LHIS_IMx@LHIS_JM-DC
              PC@HHIS_IMx@HHIS_JM-DC

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/HISTAGEPS.rc.tmpl
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/HISTAGEPS.rc.tmpl
@@ -4,6 +4,7 @@
  
 EXPID:  >>>EXPID<<<
 EXPDSC: ensemble_bkg
+Allow_Overwrite: .true.
  
 COLLECTIONS: 'prog.eta'
 # WxMaps and Meteograms

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/HISTAOSE.rc.tmpl
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/HISTAOSE.rc.tmpl
@@ -4,6 +4,7 @@
  
 EXPID:  >>>EXPID<<<
 EXPDSC: ensemble_bkg
+Allow_Overwrite: .true.
  
 COLLECTIONS: 'bkg.eta'
 @HRESAENS    'Bkg.eta'

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/obs1gsi_mean.rc
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/obs1gsi_mean.rc
@@ -170,6 +170,7 @@ OBS_INPUT::
    iasibufr       iasi        metop-c     iasi_metop-c          0.0     3      0        ncep_mtiasi_bufr
    atmsbufr       atms        npp         atms_npp              0.0     1      0        ncep_atms_bufr
    atmsbufr       atms        n20         atms_n20              0.0     1      0        ncep_atms_bufr
+!  atmsbufr       atms        n21         atms_n21              0.0     1      0        ncep_atms_bufr
    crisfsrbufr    cris-fsr    npp         cris-fsr_npp          0.0     3      0        ncep_crisfsr_bufr
    crisfsrbufr    cris-fsr    n20         cris-fsr_n20          0.0     3      0        ncep_crisfsr_bufr
    satwndbufr     uv          null        uv                    0.0     0      0        ncep_satwnd_bufr

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/obs1gsi_member.rc
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/obs1gsi_member.rc
@@ -170,6 +170,7 @@ OBS_INPUT::
    iasibufr       iasi        metop-c     iasi_metop-c          0.0     3      0        ncep_mtiasi_bufr
    atmsbufr       atms        npp         atms_npp              0.0     1      0        ncep_atms_bufr
    atmsbufr       atms        n20         atms_n20              0.0     1      0        ncep_atms_bufr
+!  atmsbufr       atms        n21         atms_n21              0.0     1      0        ncep_atms_bufr
    crisfsrbufr    cris-fsr    npp         cris-fsr_npp          0.0     3      0        ncep_crisfsr_bufr
    crisfsrbufr    cris-fsr    n20         cris-fsr_n20          0.0     3      0        ncep_crisfsr_bufr
    satwndbufr     uv          null        uv                    0.0     0      0        ncep_satwnd_bufr

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/setup_atmens.pl
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/setup_atmens.pl
@@ -220,7 +220,7 @@ sub init {
 
   if ( $nodename eq "hasw" ) { $ncpus_per_node = 24; }
   if ( $nodename eq "sky"  ) { $ncpus_per_node = 36; }
-  if ( $nodename eq "cas"  ) { $ncpus_per_node = 46; }
+  if ( $nodename eq "cas"  ) { $ncpus_per_node = 40; }
   $agcm_ncpus_per_node = -1;
 
 # define layout depending on resolution

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/ncep/dateutils.py
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/ncep/dateutils.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import datetime, calendar
 
 """
@@ -20,7 +21,7 @@ def dateto_hrs_since_day1CE(curdate,mixedcal=True):
     if mixedcal:
         if curdate < gregstart:
             msg = 'date must be after start of gregorian calendar (15821015)!'
-            raise ValueError, msg
+            raise ValueError( msg )
         difftime = curdate-gregstart
         hrsdiff = 24*difftime.days + difftime.seconds/3600
         return hrsdiff+hrsgregstart
@@ -32,7 +33,7 @@ def hrs_since_day1CE_todate(hrs,mixedcal=True):
     """return datetime.datetime instance given hours since 1-Jan-0001"""
     if hrs < 0.0:
         msg = "hrs must be positive!"
-        raise ValueError, msg
+        raise ValueError( msg )
     delta = datetime.timedelta(hours=1)
     if mixedcal:
         hrs_sincegreg = hrs - hrsgregstart
@@ -124,9 +125,9 @@ def dayofyear(yyyy,mm,dd):
 def getyrmon(day_of_year,yyyy=2001):
     d1 = datetime.datetime(yyyy,1,1)
     if calendar.isleap(d1.year) and day_of_year > 366:
-        raise ValueError, 'not that many days in the year'
+        raise ValueError( 'not that many days in the year' )
     if not calendar.isleap(d1.year) and day_of_year > 365:
-        raise ValueError, 'not that many days in the year'
+        raise ValueError( 'not that many days in the year' )
     d2 = d1 + (day_of_year-1)*datetime.timedelta(days=1)
     return d2.month,d2.day
 
@@ -137,8 +138,8 @@ def daysinmonth(yyyy,mm):
     return calendar.monthrange(yyyy,mm)[1]
 
 if __name__ == "__main__":
-    print dayofyear(2000,2,29)
-    print daysinmonth(2000,2)
-    print datetohrs('0001010100',mixedcal=False)
-    print datetohrs('2001010100',mixedcal=False)
-    print datetohrs('2001010100',mixedcal=True)
+    print (dayofyear(2000,2,29))
+    print (daysinmonth(2000,2))
+    print (datetohrs('0001010100',mixedcal=False))
+    print (datetohrs('2001010100',mixedcal=False))
+    print (datetohrs('2001010100',mixedcal=True))

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/ncep/randates.py
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/ncep/randates.py
@@ -1,10 +1,10 @@
+#!/usr/bin/env python
 import sys
 from dateutils import *
 import random
 date1 = sys.argv[1]
 date2 = sys.argv[2]
 nanals = int(sys.argv[3])
-dates = random.sample(daterange(date1,date2,6),nanals)
+dates = random.sample(daterange(date1,date2,24),nanals)
 for date in dates:
-    datem1 = dateshift(date,-24)
-    print '%s %s' % (date,datem1)
+    print ('%s' % date)

--- a/src/Shared/.gitignore
+++ b/src/Shared/.gitignore
@@ -10,3 +10,6 @@
 /@FMS
 /FMS
 /FMS@
+/@AeroML
+/AeroML
+/AeroML@

--- a/src/Shared/CMakeLists.txt
+++ b/src/Shared/CMakeLists.txt
@@ -2,6 +2,7 @@ esma_add_subdirectories (
   @MAPL
   @GMAO_Shared
   @NCEP_Shared
+  @AeroML/src
   )
 
 # Special case - FMS is built twice with two


### PR DESCRIPTION
This updates GEOS-IT to SLES15.

The also syncs all changes that had been sitting on the side (under dao_ops) into a consistent update to GEOS-IT. In the migration to SLES15, both GSI and the GCM are zero diff, but the GAAS analysis - specifically the NN is not zero diff; the changes to python3 introduce round-off changes to the generated observations and correspondingly to the incremental solution from PSAS.

Users should know that they, when running the DAS on cascade-sles15 (cas15), they must:

1) edit the file run/gaas/ana_aod.j.tmpl and add the following line to the slurm directives:
       #SBATCH --reservations=sles15_cas
2) if running before 20240202_12z, edit AGCM.rc.tmpl in both the run and fcst directories and comment out the line:
USE_TRACER_SCAVEN: 1

3) when setting up for near-real-time, make sure emissions settings in run/gocart are consistent with actual  GEOS-IT for the corresponding period.

