### PR TITLE
Remove possibly corrupt file before GCM runs

### DIFF
--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/gcm_ensemble.csh
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/gcm_ensemble.csh
@@ -329,7 +329,19 @@ if ( -d $ENSWORK/ensctrl ) then
       gcm_ensset_rc.csh $expid $nymdb $nhmsb $tfcst $nlons $nlats ensctrl
     
       cd $ENSWORK/ensctrl
+
+      # handle existing checkpoint: remove to avoid MAPL complains
       /bin/rm *_checkpoint*$NCSUFFIX
+
+      # make sure possibly corrupt model output gets removed
+      foreach myncsfx ( `ls $expid.*.$NCSUFFIX` )
+        if ( ! -l $myncsfx ) then
+          getgfiodim.x $myncsfx 
+          if ($status) then
+             /bin/rm $myncsfx
+          endif
+        endif
+      end
 
       if( -e cap_restart ) /bin/rm cap_restart
       echo $nymdb $nhmsb > cap_restart
@@ -439,7 +451,19 @@ if(! -e .DONE_ENSFCST ) then
      if(! -e $ENSWORK/.DONE_MEM${memtag}_${MYNAME}.$yyyymmddhh ) then
 
         gcm_ensset_rc.csh $expid $nymdb $nhmsb $tfcst $nlons $nlats mem$memtag
+
+        # handle existing checkpoint: remove to avoid MAPL complains
         /bin/rm *_checkpoint*$NCSUFFIX
+
+        # make sure possibly corrupt model output gets removed
+        foreach myncsfx ( `ls $expid.*.$NCSUFFIX` )
+          if ( ! -l $myncsfx ) then
+            getgfiodim.x $myncsfx 
+            if ($status) then
+               /bin/rm $myncsfx
+            endif
+          endif
+        end
 
         # Run ensemble
         # ------------


### PR DESCRIPTION
When model ensemble member fails, the model leaves behind some of its history output. Typically, if the history output is sane, a resubmission of the ensemble successfully completes the previously failed run. At times, however, some of the history output might be corrupt, in these cases, a resubmission of the ensemble will continue to fail since logics in MAPL will want to open the existing file - however, for corrupt files this causes the model to fail .. and it will fail over and over again. 
Changing the MAPL logics to check on the sanity of files it tries to open is not so simple.

This PR introduces a script logic that removes corrupt files before the model starts running. This has been tests on a couple of failed cases and it seems to work like a charm.