### PR TITLE
pointer of AOD flk moved to llk

### DIFF
--- a/src/Applications/GEOSdas_App/testsuites/x0051.input
+++ b/src/Applications/GEOSdas_App/testsuites/x0051.input
@@ -207,7 +207,7 @@ Do Aerosol Analysis (y/n)? [y]
 > 
 
 AOD OBSERVING CLASSES [or type 'none']?
-> mod04_061_flk,myd04_061_flk,aeronet_obs_llk
+> mod04_061_llk,myd04_061_llk,aeronet_obs_llk
 
 Enable GAAS feedback to model (y/n)? [y]
 > 


### PR DESCRIPTION
This is to make sure when people run an x0051-like experiment they get the AOD observations from the historic location - as opposed to FLK - the data is no longer available under FLK for the initial period covered  by x0051.