### PR TITLE
Var 4d no longer writes out inc; inc generated offline

### DIFF
--- a/src/Applications/GEOSdas_App/jedi/etc/CMakeLists.txt
+++ b/src/Applications/GEOSdas_App/jedi/etc/CMakeLists.txt
@@ -1,6 +1,7 @@
 set (ALLETC
    JEDIanaConfig.csh
    SWELLConfig.csh
+   diffstates_geos.yaml
    geos_3dvar.yaml
    geos_3dfgat.yaml
    geos_hyb4denvar.yaml

--- a/src/Applications/GEOSdas_App/jedi/etc/JEDIanaConfig.csh
+++ b/src/Applications/GEOSdas_App/jedi/etc/JEDIanaConfig.csh
@@ -27,12 +27,14 @@ setenv JEDI_ROOT @JEDI_ROOT
 # Specific to run procedure
 setenv JEDI_RUN_ANA      1
 setenv JEDI_RUN_CNVANA   0   # convert cc ana and/or inc output to ll
+setenv JEDI_RUN_GETINC   @JEDI_RUN_GETINC   # calc cubed inc from diff of cubed ana and bkg
 setenv JEDI_RUN_UPDRST   0   # not desirable
 
 setenv JEDI_ADDINC_MPIRUN "mpirun -np 12"
 setenv JEDI_CNVANA_MPIRUN "mpirun -np 12"
 setenv JEDI_CNVENS_MPIRUN "mpirun -np 12"
 setenv JEDI_CNVINC_MPIRUN "mpirun -np 12"
+setenv JEDI_GETINC_MPIRUN "mpirun -np 6"
 setenv JEDI_NCPUS @JEDI_VAR_NCPUS
 setenv JEDI_FV3VAR_MPIRUN "mpirun -perhost @JEDI_VAR_PERHOST -np $JEDI_NCPUS"
 

--- a/src/Applications/GEOSdas_App/jedi/etc/convertana_geos.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/convertana_geos.yaml
@@ -1,0 +1,33 @@
+input geometry:
+  fms initialization:
+    namelist filename: fv3-jedi/fv3files/fmsmpp.nml
+    field table filename: fv3-jedi/fv3files/field_table_gmao
+  akbk: fv3-jedi/fv3files/akbk72.nc4
+  npx: @JEDI_BKG_RESOL
+  npy: @JEDI_BKG_RESOL
+  npz: 72
+  field metadata override: fv3-jedi/fieldmetadata/geos.yaml
+output geometry:
+  akbk: fv3-jedi/fv3files/akbk72.nc4
+# interpolation method: bump
+  npx: @JEDI_BKG_RESOL_OUT
+  npy: @JEDI_BKG_RESOL_OUT
+  npz: 72
+  field metadata override: fv3-jedi/fieldmetadata/geos.yaml
+states:
+- input:
+    datetime: $ISO_STATES_DATE
+    filetype: cube sphere history
+    provider: geos
+    filename: &mybkg $JEDI_CUBED_BKG
+    datapath: ./
+    state variables: [ua,va,t,delp,ps,q,qi,ql,qr,qs,o3ppmv,phis,
+                  qls,qcn,cfcn,frocean,frland,varflt,ustar,bstar,
+                  zpbl,cm,ct,cq,kcbl,tsm,khl,khu,frlake,frseaice,
+                  sheleg,ts,soilt,soilm,u10m,v10m,co2]
+#vtype, stype,vfrac,
+  output:
+    filetype: cube sphere history
+    provider: geos
+    datapath: ./$OUTDIR
+    filename: *mybkg

--- a/src/Applications/GEOSdas_App/jedi/etc/diffstates_geos.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/diffstates_geos.yaml
@@ -17,7 +17,7 @@ state1:
   datetime: $ISO_STATES_DATE
   filetype: cube sphere history
   provider: geos
-  datapath: ./
+  datapath: ./ana
   filename: $JEDI_CUBED_ANA
   state variables:
   - ua
@@ -37,7 +37,7 @@ state2:
   datetime: $ISO_STATES_DATE
   filetype: cube sphere history
   provider: geos
-  datapath: ./
+  datapath: ./bkg
   filename: $JEDI_CUBED_BKG
   state variables:
   - ua
@@ -56,5 +56,5 @@ state2:
 output:
   filetype: auxgrid
   gridtype: latlon
-  datapath: ./
+  datapath: ./inc
   filename: $EXPID.jedi_inc1.eta.

--- a/src/Applications/GEOSdas_App/jedi/etc/diffstates_geos.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/diffstates_geos.yaml
@@ -1,0 +1,60 @@
+state geometry:
+  fms initialization:
+    namelist filename: fv3-jedi/fv3files/fmsmpp.nml
+    field table filename: fv3-jedi/fv3files/field_table_gmao
+  akbk: fv3-jedi/fv3files/akbk72.nc4
+  npx: @JEDI_BKG_RESOL
+  npy: @JEDI_BKG_RESOL
+  npz: 72
+  field metadata override: fv3-jedi/fieldmetadata/geos.yaml
+increment geometry:
+  akbk: fv3-jedi/fv3files/akbk72.nc4
+  npx: @JEDI_BKG_RESOL
+  npy: @JEDI_BKG_RESOL
+  npz: 72
+  field metadata override: fv3-jedi/fieldmetadata/geos.yaml
+state1:
+  datetime: $ISO_STATES_DATE
+  filetype: cube sphere history
+  provider: geos
+  datapath: ./
+  filename: $JEDI_CUBED_ANA
+  state variables:
+  - ua
+  - va
+  - t
+  - q
+  - qi
+  - ql
+  - qr
+  - qs
+  - o3ppmv
+  - ps
+  - phis
+  - ts
+# - delp
+state2:
+  datetime: $ISO_STATES_DATE
+  filetype: cube sphere history
+  provider: geos
+  datapath: ./
+  filename: $JEDI_CUBED_BKG
+  state variables:
+  - ua
+  - va
+  - t
+  - q
+  - qi
+  - ql
+  - qr
+  - qs
+  - o3ppmv
+  - ps
+  - phis
+  - ts
+# - delp
+output:
+  filetype: auxgrid
+  gridtype: latlon
+  datapath: ./
+  filename: $EXPID.jedi_inc1.eta.

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_hyb4denvar.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_hyb4denvar.yaml
@@ -36221,13 +36221,13 @@ final:
     departures: oman
   prints:
     frequency: PT1H
-#output:
-#  datapath: ./
-#  filename: $EXPID.ana.ceta.%yyyy%mm%dd_%hh%MM%ssz.nc4
-#  filetype: cube sphere history
-#  first: PT0H
-#  frequency: PT1H
-#  provider: geos
+output:
+  datapath: ./
+  filename: $EXPID.ana.ceta.%yyyy%mm%dd_%hh%MMz.nc4
+  filetype: cube sphere history
+  first: PT0H
+  frequency: PT1H
+  provider: geos
 variational:
   iterations:
   - ninner: '50'
@@ -36266,46 +36266,46 @@ variational:
       name: Identity
       tstep: PT1H
       variable change: Identity
-    online diagnostics:
-      increment:
-        state component:
-          states:
-          - date: $JEDI_ISO_DATE_001
-            datapath: ./
-            filename: $EXPID.jedi_inc1.eta.
-            filetype: auxgrid
-            gridtype: latlon
-          - date: $JEDI_ISO_DATE_002
-            datapath: ./
-            filename: $EXPID.jedi_inc1.eta.
-            filetype: auxgrid
-            gridtype: latlon
-          - date: $JEDI_ISO_DATE_003
-            datapath: ./
-            filename: $EXPID.jedi_inc1.eta.
-            filetype: auxgrid
-            gridtype: latlon
-          - date: $JEDI_ISO_DATE_004
-            datapath: ./
-            filename: $EXPID.jedi_inc1.eta.
-            filetype: auxgrid
-            gridtype: latlon
-          - date: $JEDI_ISO_DATE_005
-            datapath: ./
-            filename: $EXPID.jedi_inc1.eta.
-            filetype: auxgrid
-            gridtype: latlon
-          - date: $JEDI_ISO_DATE_006
-            datapath: ./
-            filename: $EXPID.jedi_inc1.eta.
-            filetype: auxgrid
-            gridtype: latlon
-          - date: $JEDI_ISO_DATE_007
-            datapath: ./
-            filename: $EXPID.jedi_inc1.eta.
-            filetype: auxgrid
-            gridtype: latlon
-      write increment: true
+#   online diagnostics:
+#     increment:
+#       state component:
+#         states:
+#         - date: $JEDI_ISO_DATE_001
+#           datapath: ./
+#           filename: $EXPID.jedi_inc1.eta.
+#           filetype: auxgrid
+#           gridtype: latlon
+#         - date: $JEDI_ISO_DATE_002
+#           datapath: ./
+#           filename: $EXPID.jedi_inc1.eta.
+#           filetype: auxgrid
+#           gridtype: latlon
+#         - date: $JEDI_ISO_DATE_003
+#           datapath: ./
+#           filename: $EXPID.jedi_inc1.eta.
+#           filetype: auxgrid
+#           gridtype: latlon
+#         - date: $JEDI_ISO_DATE_004
+#           datapath: ./
+#           filename: $EXPID.jedi_inc1.eta.
+#           filetype: auxgrid
+#           gridtype: latlon
+#         - date: $JEDI_ISO_DATE_005
+#           datapath: ./
+#           filename: $EXPID.jedi_inc1.eta.
+#           filetype: auxgrid
+#           gridtype: latlon
+#         - date: $JEDI_ISO_DATE_006
+#           datapath: ./
+#           filename: $EXPID.jedi_inc1.eta.
+#           filetype: auxgrid
+#           gridtype: latlon
+#         - date: $JEDI_ISO_DATE_007
+#           datapath: ./
+#           filename: $EXPID.jedi_inc1.eta.
+#           filetype: auxgrid
+#           gridtype: latlon
+#     write increment: true
 # - ninner: '25'
 #   diagnostics:
 #     departures: ombg

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_hyb4denvar.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_hyb4denvar.yaml
@@ -36222,7 +36222,7 @@ final:
   prints:
     frequency: PT1H
 output:
-  datapath: ./
+  datapath: ./ana
   filename: $EXPID.ana.ceta.%yyyy%mm%dd_%hh%MMz.nc4
   filetype: cube sphere history
   first: PT0H

--- a/src/Applications/GEOSdas_App/jedi/jedi_run.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_run.csh
@@ -59,6 +59,7 @@ if ( !($?FVWORK)           )  setenv FAILED   1
 if ( !($?JEDI_ROOT)        )  setenv FAILED   1
 if ( !($?JEDI_RUN_ANA)     )  setenv FAILED   1
 if ( !($?JEDI_RUN_CNVANA)  )  setenv FAILED   1
+if ( !($?JEDI_RUN_GETINC)  )  setenv FAILED   1
 if ( !($?JEDI_RUN_UPDRST)  )  setenv FAILED   1
 if ( !($?JEDI_VAROFFSET)   )  setenv FAILED   1
 if ( !($?JEDI_ADDINC_MPIRUN) )  setenv FAILED   1
@@ -202,6 +203,33 @@ if ( $JEDI_RUN_ANA ) then
    endif
 endif
 
+if ( $JEDI_RUN_GETINC ) then
+
+  if ( ! -e Config/diffstates_geos.yaml ) then
+    echo " ${MYNAME}: missing diffstates_geos.yaml file, aborting ... "
+    exit 1
+  endif
+
+  # Calculate increment on the cubed offline from cubed ana and bkg
+  # ATTENTION: 1. This should be parallelized.
+  #            2. mkiau has been enabled to handled cubed states, so this
+  #               can be bypassed at some point.
+  # ---------------------------------------------------------------
+  foreach cana (`ls *ana.ceta*` )
+     set  ttag = `echo $cana | cut -d. -f3`
+     set yyyys = `echo $ttag | cut -c1-4`
+     set   mms = `echo $ttag | cut -c5-6`
+     set   dds = `echo $ttag | cut -c7-8`
+     set   hhs = `echo $ttag | cut -c10-11`
+     set  cbkg = `ls bkg.${yyyys}${mms}${dds}_${hhs}*nc4`
+     setenv JEDI_CUBED_ANA $cana
+     setenv JEDI_CUBED_BKG $cbkg
+     setenv ISO_STATES_DATE "${yyyys}-${mms}-${dds}T${hhs}:00:00Z"
+     vED -env $FVHOME/run/jedi/Config/diffinc_geos.yaml -o diffstates_geos.yaml
+     $JEDI_GETINC_MPIRUN $JEDIBUILD/bin/fv3jedi_diffstates.x Config/diffstates_geos.yaml
+  end
+
+endif
 
 if ( $JEDI_RUN_CNVANA ) then
 

--- a/src/Applications/GEOSdas_App/jedi/jedi_run.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_run.csh
@@ -209,8 +209,9 @@ if ( $JEDI_RUN_GETINC ) then
   #            2. mkiau has been enabled to handled cubed states, so this
   #               can be bypassed at some point.
   # ---------------------------------------------------------------
-  foreach cana (`ls *ana.ceta*` )
-     set  ttag = `echo $cana | cut -d. -f3`
+  foreach cana (`ls ana/*ana.ceta*` )
+     set this = `basename $cana`
+     set  ttag = `echo $this | cut -d. -f3`
      set yyyys = `echo $ttag | cut -c1-4`
      set   mms = `echo $ttag | cut -c5-6`
      set   dds = `echo $ttag | cut -c7-8`

--- a/src/Applications/GEOSdas_App/jedi/jedi_run.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_run.csh
@@ -211,7 +211,7 @@ if ( $JEDI_RUN_GETINC ) then
   # ---------------------------------------------------------------
   foreach cana (`ls ana/*ana.ceta*` )
      set this = `basename $cana`
-     set  ttag = `echo $this | cut -d. -f3`
+     set  ttag = `echo $this | cut -d. -f4`
      set yyyys = `echo $ttag | cut -c1-4`
      set   mms = `echo $ttag | cut -c5-6`
      set   dds = `echo $ttag | cut -c7-8`

--- a/src/Applications/GEOSdas_App/jedi/jedi_run.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_run.csh
@@ -174,8 +174,7 @@ if ( $JEDI_RUN_ANA ) then
    endif
 
    if ( -e $FVHOME/run/jedi/jedi_run_var.j ) then
-      vED -env $FVHOME/run/jedi/jedi_run_var.j -o jedi_run_var.j
-      sbatch -W jedi_run_var.j
+      sbatch -W $FVHOME/run/jedi/jedi_run_var.j
       sleep 2
    else
       $JEDI_FV3VAR_MPIRUN $JEDIBUILD/bin/fv3jedi_var.x $MYCONF |& tee -a $FVWORK/$JEDIVARLOG
@@ -205,11 +204,6 @@ endif
 
 if ( $JEDI_RUN_GETINC ) then
 
-  if ( ! -e Config/diffstates_geos.yaml ) then
-    echo " ${MYNAME}: missing diffstates_geos.yaml file, aborting ... "
-    exit 1
-  endif
-
   # Calculate increment on the cubed offline from cubed ana and bkg
   # ATTENTION: 1. This should be parallelized.
   #            2. mkiau has been enabled to handled cubed states, so this
@@ -221,12 +215,12 @@ if ( $JEDI_RUN_GETINC ) then
      set   mms = `echo $ttag | cut -c5-6`
      set   dds = `echo $ttag | cut -c7-8`
      set   hhs = `echo $ttag | cut -c10-11`
-     set  cbkg = `ls bkg.${yyyys}${mms}${dds}_${hhs}*nc4`
-     setenv JEDI_CUBED_ANA $cana
-     setenv JEDI_CUBED_BKG $cbkg
-     setenv ISO_STATES_DATE "${yyyys}-${mms}-${dds}T${hhs}:00:00Z"
-     vED -env $FVHOME/run/jedi/Config/diffinc_geos.yaml -o diffstates_geos.yaml
-     $JEDI_GETINC_MPIRUN $JEDIBUILD/bin/fv3jedi_diffstates.x Config/diffstates_geos.yaml
+     if ( -e Config/diffstates_geos_${yyyys}${mms}${dds}_${hhs}z.yaml ) then
+        $JEDI_GETINC_MPIRUN $JEDIBUILD/bin/fv3jedi_diffstates.x Config/diffstates_geos_${yyyys}${mms}${dds}_${hhs}z.yaml
+     else
+        echo " ${MYNAME}: missing Config/diffstates_geos_${yyyys}${mms}${dds}_${hhs}z.yaml file, aborting ... "
+        exit 1
+     endif
   end
 
 endif

--- a/src/Applications/GEOSdas_App/jedi/jedi_set.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_set.csh
@@ -319,60 +319,66 @@ if ( $JEDI_HYBRID ) then
   endif
 endif
 
-cd bkg
-setenv NYMD  $nymdb # initial date of current cycle
-setenv NHMS  $nhmsb # initial time of current cycle
-setenv NYMDP $nymdp # initial date of previous cycle
-setenv NHMSP $nhmsp # initial time of previous cycle
-setenv ACQWORK $JEDIWRK/bkg
-vED -env $FVHOME/run/jedi/jedi_acquire_bkg.j -o jedi_acquire_bkg.j
-if ( $BATCH_SUBCMD == "sbatch" ) then
-   sbatch -W -o jedi_acq.log jedi_acquire_bkg.j
-else
-   qsub -W block=true -o jedi_acq.log jedi_acquire_bkg.j
+if ( ! -e $JEDIWRK/.DONE_JEDI_GET_BKG_${nymdb}_${nhmsb} ) then
+  cd bkg
+  setenv NYMD  $nymdb # initial date of current cycle
+  setenv NHMS  $nhmsb # initial time of current cycle
+  setenv NYMDP $nymdp # initial date of previous cycle
+  setenv NHMSP $nhmsp # initial time of previous cycle
+  setenv ACQWORK $JEDIWRK/bkg
+  vED -env $FVHOME/run/jedi/jedi_acquire_bkg.j -o jedi_acquire_bkg.j
+  if ( $BATCH_SUBCMD == "sbatch" ) then
+     sbatch -W -o jedi_acq.log jedi_acquire_bkg.j
+  else
+     qsub -W block=true -o jedi_acq.log jedi_acquire_bkg.j
+  endif
+  set lst = `ls $EXPID.bkgcrst.*.tar`
+  if ( $#lst == 1 ) then
+     tar xvf $lst
+     /bin/rm $EXPID.bkgcrst.*.tar
+     set lst = ( `ls *.bkg_clcv_rst*nc4` )
+     set vexpid = `echo $lst[1] | cut -d. -f1`
+     if ( $vexpid != $EXPID ) then # care for when tarball from another exp
+        foreach fn ( `ls *.bkg_clcv_rst*nc4` )
+           set sfx = `echo $fn | cut -d. -f2-`
+           /bin/mv $fn $EXPID.$sfx
+        end
+     endif
+     foreach fn ( `ls *.bkg_clcv_rst*nc4` )
+        set ttag = `echo $fn | cut -d. -f3-`
+        set ymd = `echo $ttag | cut -c1-8`
+        set hm  = `echo $ttag | cut -c10-13`
+        set sfx = ${ymd}T${hm}00Z.nc4 # cope swell reinvented notation
+        ln -sf $fn bkg.$sfx
+     end
+     cd $JEDIWRK
+     ln -sf $JEDIWRK/bkg/bkg.*.nc4 .
+     if ( -e $JEDIETC/convertinc_geos.yaml ) then
+        set lst = (`ls bkg.*.nc4`)
+        set cres  = `getgfiodim.x $lst[1]`
+        @ jcres = $cres[1] + 1
+        setenv JEDI_BKG_RESOL $jcres
+        vED -env $JEDIETC/convertinc_geos.yaml -o $JEDIWRK/Config/convertinc_geos.yaml
+     endif
+     cd -
+     # the following is a nedeed hack due to inconsistencies in MAPL
+#    if ( $MAPLFIX ) then
+#       mkdir Ori
+#       foreach fn ( `ls *.bkg_clcv_rst*nc4` )
+#          /bin/mv $fn Ori/
+#          $FVHOME/run/jedi/convert_xdimydim_2_latlon.py -i Ori/$fn -o $fn 
+#       end
+#    endif
+  else
+     echo " ${MYNAME}: failed to retrieve bkg tar ball, aborting ..."
+     exit(3)
+  endif
+  touch $JEDIWRK/.DONE_JEDI_GET_BKG_${nymdb}_${nhmsb}
 endif
-set lst = `ls $EXPID.bkgcrst.*.tar`
-if ( $#lst == 1 ) then
-   tar xvf $lst
-   /bin/rm $EXPID.bkgcrst.*.tar
-   set lst = ( `ls *.bkg_clcv_rst*nc4` )
-   set vexpid = `echo $lst[1] | cut -d. -f1`
-   if ( $vexpid != $EXPID ) then # care for when tarball from another exp
-      foreach fn ( `ls *.bkg_clcv_rst*nc4` )
-         set sfx = `echo $fn | cut -d. -f2-`
-         /bin/mv $fn $EXPID.$sfx
-      end
-   endif
-   foreach fn ( `ls *.bkg_clcv_rst*nc4` )
-      set ttag = `echo $fn | cut -d. -f3-`
-      set ymd = `echo $ttag | cut -c1-8`
-      set hm  = `echo $ttag | cut -c10-13`
-      set sfx = ${ymd}T${hm}00Z.nc4 # cope swell reinvented notation
-      ln -sf $fn bkg.$sfx
-   end
-   cd $JEDIWRK
-   ln -sf $JEDIWRK/bkg/bkg.*.nc4 .
-   if ( -e $JEDIETC/convertinc_geos.yaml ) then
-      set lst = (`ls bkg.*.nc4`)
-      set cres  = `getgfiodim.x $lst[1]`
-      @ jcres = $cres[1] + 1
-      setenv JEDI_BKG_RESOL $jcres
-      vED -env $JEDIETC/convertinc_geos.yaml -o $JEDIWRK/Config/convertinc_geos.yaml
-   endif
-   cd -
-   # the following is a nedeed hack due to inconsistencies in MAPL
-#  if ( $MAPLFIX ) then
-#     mkdir Ori
-#     foreach fn ( `ls *.bkg_clcv_rst*nc4` )
-#        /bin/mv $fn Ori/
-#        $FVHOME/run/jedi/convert_xdimydim_2_latlon.py -i Ori/$fn -o $fn 
-#     end
-#  endif
-else
-   echo " ${MYNAME}: failed to retrieve bkg tar ball, aborting ..."
-   exit(3)
-endif
+
+# When applicable, retrieve ensemble background
 if( $JEDI_GET_ENSBKG ) then
+ if ( ! -e $JEDIWRK/.DONE_JEDI_GET_ENSBKG_${nymdb}_${nhmsb} ) then
    cd $JEDIWRK/atmens
    setenv NYMD  $nymdb # initial date of current cycle
    setenv NHMS  $nhmsb # initial time of current cycle
@@ -415,6 +421,30 @@ if( $JEDI_GET_ENSBKG ) then
       echo " ${MYNAME}: failed to retrieve ensemble tar ball, aborting ..."
       exit(4)
    endif
+   touch $JEDIWRK/.DONE_JEDI_GET_ENSBKG_${NYMD}_${NHMS}
+ endif
+endif
+
+# In case running 4D hybrid, create yamls needed for offline inc gen
+# ------------------------------------------------------------------
+if ( $JEDI_HYBRID ) then
+  cd $JEDIWRK
+  if ( ! -e Config/diffstates_geos.yaml ) then
+     echo " ${MYNAME}: missing Config/diffstates_geos.yaml file, aborting ... "
+    exit 1
+  endif
+  foreach cbkg (`ls bkg.*.nc4` )
+     set  ttag = `echo $cbkg | cut -d. -f2`
+     set yyyys = `echo $ttag | cut -c1-4`
+     set   mms = `echo $ttag | cut -c5-6`
+     set   dds = `echo $ttag | cut -c7-8`
+     set   hhs = `echo $ttag | cut -c10-11`
+     set  cana = $EXPID.ana.ceta.${yyyys}${mms}${dds}_${hhs}00z.nc4 # wired for now
+     setenv JEDI_CUBED_BKG $cbkg
+     setenv JEDI_CUBED_ANA $cana
+     setenv ISO_STATES_DATE "${yyyys}-${mms}-${dds}T${hhs}:00:00Z"
+     vED -env Config/diffstates_geos.yaml -o Config/diffstates_geos_${yyyys}${mms}${dds}_${hhs}z.yaml
+   end
 endif
 
 # If here, likely successful

--- a/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
+++ b/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
@@ -261,6 +261,9 @@ cp("$FVROOT/etc/jedi/geos_${scheme}.yaml","$JEDIHOME/Config/geosvar.yaml");
 # take of resolution and layout
 ed_conf_rc ("$JEDIHOME","JEDIanaConfig.csh");
 ed_var_yaml ("$JEDIHOME/Config","geosvar.yaml");
+if ( $scheme eq "hyb4denvar" ) {
+  ed_var_yaml ("$JEDIHOME/Config","diffstates_geos.yaml");
+}
 
 # take care of satbias acq
 ed_jedibkg_acq   ("$JEDIHOME/Config");
@@ -368,7 +371,11 @@ sub ed_conf_rc {
   my($acq);
 
   $jedihyb = 0;
-  if ( $scheme == "hyb4denvar" ) { $jedihyb = 1 };
+  $jediinc = 0;
+  if ( $scheme == "hyb4denvar" ) { 
+     $jedihyb = 1;
+     $jediinc = 1;
+  }
 
   $tmprc  = "$mydir/tmp.rc";
   $thisrc = "$mydir/$conffn";
@@ -385,6 +392,7 @@ sub ed_conf_rc {
         if($rcd =~ /\@JEDI_INPUT/)          {$rcd=~ s/\@JEDI_INPUT/$jediinput/g;  }
         if($rcd =~ /\@JEDI_OBS_OPT/)        {$rcd=~ s/\@JEDI_OBS_OPT/$jedi_obs_opt/g;  }
         if($rcd =~ /\@JEDI_ROOT/)           {$rcd=~ s/\@JEDI_ROOT/$jediroot/g;  }
+        if($rcd =~ /\@JEDI_RUN_GETINC/)     {$rcd=~ s/\@JEDI_RUN_GETINC/$jediinc/g;  }
         if($rcd =~ /\@JEDI_STATIC_FILES/)   {$rcd=~ s/\@JEDI_STATIC_FILES/$jedistatic/g;  }
         if($rcd =~ /\@JEDI_VAR_NCPUS/)      {$rcd=~ s/\@JEDI_VAR_NCPUS/$ncpus_var/g;  }
         if($rcd =~ /\@JEDI_VAR_PERHOST/)    {$rcd=~ s/\@JEDI_VAR_PERHOST/$perhost_var/g;  }


### PR DESCRIPTION
There is a considerable inefficiency in fv3-jedi 4D writing out lat-lon increments. The changes here get the code to write out the analysis and the increment get derived offline. 

Sure we could ask JEDI to write out the cubed increments directly - that's not a performance hog - but the output file is in a very odd format; difficult to handle in other apps.

zero diff to general (validated GEOS ADAS components) 