### PR TITLE
cover for inconsistency  in jedi

### DIFF
--- a/src/Applications/GEOSdas_App/jedi/etc/JEDIanaConfig.csh
+++ b/src/Applications/GEOSdas_App/jedi/etc/JEDIanaConfig.csh
@@ -5,7 +5,7 @@ setenv JEDI_RUN    1           # run JEDI var executable
 setenv JEDI_HYBRID @JEDI_HYBRID           # control opts for hyb JEDI
 setenv JEDI_MKIAU  1           # calculates IAU output
 setenv JEDI_POST   0           # process results (move files, etc)
-setenv JEDI_IAU_OVERWRITE  0   # overwrite GSI-IAU with JEDI-IAU (when cycling)
+setenv JEDI_IAU_OVERWRITE  @JEDI_IAU_OVERWRITE   # overwrite GSI-IAU with JEDI-IAU (when cycling)
 setenv JEDI_RUN_ADANA_TEST 0   # run adjoint JEDI-Var
 setenv JEDI_VAROFFSET 10800    # background time offset
 setenv JEDI_FEEDBACK_VARBC @JEDI_FEEDBACK_VARBC   # controls whether or not to feedback biases

--- a/src/Applications/GEOSdas_App/jedi/jedi_run.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_run.csh
@@ -223,6 +223,7 @@ if ( $JEDI_RUN_GETINC ) then
         exit 1
      endif
   end
+  /bin/mv $EXPID.*inc*nc4 ./inc  # apparently diffstate does not listen to datapath on output
 
 endif
 

--- a/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
+++ b/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
@@ -391,6 +391,7 @@ sub ed_conf_rc {
         if($rcd =~ /\@JEDI_HYBRID/)         {$rcd=~ s/\@JEDI_HYBRID/$jedihyb/g;  }
         if($rcd =~ /\@JEDI_INPUT/)          {$rcd=~ s/\@JEDI_INPUT/$jediinput/g;  }
         if($rcd =~ /\@JEDI_OBS_OPT/)        {$rcd=~ s/\@JEDI_OBS_OPT/$jedi_obs_opt/g;  }
+        if($rcd =~ /\@JEDI_IAU_OVERWRITE/)  {$rcd=~ s/\@JEDI_IAU_OVERWRITE/$nogsi/g;  }
         if($rcd =~ /\@JEDI_ROOT/)           {$rcd=~ s/\@JEDI_ROOT/$jediroot/g;  }
         if($rcd =~ /\@JEDI_RUN_GETINC/)     {$rcd=~ s/\@JEDI_RUN_GETINC/$jediinc/g;  }
         if($rcd =~ /\@JEDI_STATIC_FILES/)   {$rcd=~ s/\@JEDI_STATIC_FILES/$jedistatic/g;  }


### PR DESCRIPTION
It turns out that fv3jedi_diffstates does not listen to the datapath in the output section of the yaml. This fix has the script place the output files in the correct place.

This also sets OVERWRITE IAU when NO GSI is in place