### PR TITLE
This file should handle on the ens background

### DIFF
--- a/src/Applications/GEOSdas_App/jedi/etc/jedi_acquire_ebkg.j
+++ b/src/Applications/GEOSdas_App/jedi/etc/jedi_acquire_ebkg.j
@@ -4,13 +4,9 @@
 #SBATCH --time=1:00:00
 
 cd $ACQWORK
-if ( $JEDI_GET_ENSBKG ) then
-  if ( $JEDI_HYBRID == 1 ) then
-    acquire -v -rc $JEDIETC/jedi_ebkg.acq  -d $ACQWORK -s $FVHOME/spool   -ssh $NYMD $NHMS  060000 1
-  else
-    acquire -v -rc $JEDIETC/jedi_ebkgx.acq  -d $ACQWORK -s $FVHOME/spool  -ssh $NYMD $NHMS  060000 1
-  endif
+if ( $JEDI_HYBRID == 1 ) then
+  acquire -v -rc $JEDIETC/jedi_ebkg.acq  -d $ACQWORK -s $FVHOME/spool   -ssh $NYMD $NHMS  060000 1
+else
+  acquire -v -rc $JEDIETC/jedi_ebkgx.acq  -d $ACQWORK -s $FVHOME/spool  -ssh $NYMD $NHMS  060000 1
 endif
-acquire -v -rc $JEDIETC/jedi_bkg.acq  -d $ACQWORK -s $FVHOME/spool   -ssh $NYMDP $NHMSP 060000 1
-#acquire -v -rc $JEDIETC/jedi_bkg.acq  -d $ACQWORK -s $FVHOME/spool   -ssh $NYMD $NHMS 060000 1
 exit


### PR DESCRIPTION
Trivial change - this file cannot be handling the regular background tar ball (only the atmos ensemble).

zero diff - presently not used in regular way of exercising the ADAS.