### PR TITLE
Fix for incorrect handling of AOD in fcst mode

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -92,7 +92,7 @@ GEOSana_GridComp:
 mksi:
    local: ./src/Components/@GEOSana_GridComp/GEOSaana_GridComp/GSI_GridComp/@mksi
    remote: ../GEOS_mksi.git
-   tag: v5.42.4
+   tag: v5.42.5
    develop: develop
 
 GEOSgcm_GridComp:

--- a/components.yaml
+++ b/components.yaml
@@ -251,7 +251,7 @@ umwm:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: g2.3.8.3
+  tag: v2.3.8.4
   develop: develop
 
 Ocean-LETKF:

--- a/src/Applications/GEOSdas_App/GEOSdas.csm
+++ b/src/Applications/GEOSdas_App/GEOSdas.csm
@@ -1946,6 +1946,17 @@ exit 1
 
      endif
 
+#    A bit of a hack to cope with latest handing of GAAS settings
+#    ------------------------------------------------------------
+     foreach fn (`ls $EXPID.aod*.$NCSUFFIX`)
+       set sfx = `echo $fn | cut -d. -f2-`
+       if ( -e das.$sfx ) then
+          /bin/rm das.$sfx
+       else
+          ln -sf $fn das.$sfx 
+       endif
+     end
+
                               # Last line of GetAODinfo4Fcst_()
 \end
 #.............................................................................
@@ -4125,8 +4136,13 @@ endif
            cat WSUB_ExtData.tmp | sed -e '/^WSUB_NATURE/ s#ExtData.*#/dev/null#' > WSUB_ExtData.rc
            /bin/rm WSUB_ExtData.tmp
 
-         #  Run bundleParser.py
+         #  Run bundleParser.py (note: needed since ADAS does not set pythonpath)
          #  -------------------
+         set this = `which bundleParser.py`
+         if ($status) then
+            Call AbnormalExit_( 99 )
+         endif
+         /bin/cp $this .
          python bundleParser.py
          construct_extdata_yaml_list.py $FVWORK/GEOS_ChemGridComp.rc
 
@@ -4797,8 +4813,13 @@ endif
 
    cd -
 
-  # Run bundleParser.py
-  #---------------------
+  # Run bundleParser.py (note: needed since ADAS does not set pythonpath)
+  #--------------------
+  set this = `which bundleParser.py`
+  if ($status) then
+     Call AbnormalExit_( 99 )
+  endif
+  /bin/cp $this .
   python bundleParser.py
   construct_extdata_yaml_list.py $FVWORK/GEOS_ChemGridComp.rc
 

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/gcm_ensset_rc.csh
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/gcm_ensset_rc.csh
@@ -380,8 +380,14 @@ cd $ENSWORK/$member
          endif
          sed -f sed_file  $this_hist  > ./HISTORY.rc
 
-        #  Run bundleParser.py
+        #  Run bundleParser.py (note: needed since ensADAS does not set pythonpath)
         #  -------------------
+        set this = `which bundleParser.py`
+        if ($status) then
+           echo " ${MYNAME}: cannot find bundleParser.py, aborting ..."
+           exit 2 
+        endif
+        /bin/cp $this .
         python bundleParser.py
         construct_extdata_yaml_list.py ./GEOS_ChemGridComp.rc
 


### PR DESCRIPTION
This is zero-diff in ADAS cycling; but non-zero diff in offline forecasts. 

This fixes a bug in offline forecasts, which have not been seeing the AOD analyses, likely, since the introduction of G2G. Rob Lucchesi notice something odd in the gcm.log in the forecast and an inconsistency w/ when the DAS runs ... I looked closely into it and found that indeed the forecasts were not creating the proper links to the AOD files so the model would see them.

There is also an issue related to the bundleParser.py that has not been working properly in either ADAS or ADAS-fcsts. It's not clear why things related to the setting of Chem still work. The fix brought here related to this, does not seem to affect results in one instance testing - not clear whether results change when a year boundary is crossed, or something else. From what I can tell, the failure of the program to run should have been causing a crash ... but it's not!

I am indicating zero-diff since the bug here affects only offline forecasts which are not done in FP.