### PR TITLE
AMSUA MetopC 4-6 off; revise OMI source

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -92,7 +92,7 @@ GEOSana_GridComp:
 mksi:
    local: ./src/Components/@GEOSana_GridComp/GEOSaana_GridComp/GSI_GridComp/@mksi
    remote: ../GEOS_mksi.git
-   tag: v5.42.5
+   tag: v5.42.6
    develop: develop
 
 GEOSgcm_GridComp:

--- a/src/Applications/GEOSdas_App/testsuites/prePP.input
+++ b/src/Applications/GEOSdas_App/testsuites/prePP.input
@@ -150,7 +150,7 @@ Which main class of ObsSys (1: NRT; 2: MERRA; 3: MERRA-2; 4: GEOS-IT; 5: R21C)? 
 > 1
 
 OBSERVING SYSTEM CLASSES?
-> disc_airs_bufr,disc_amsua_bufr,gmao_amsr2_bufr,gmao_gmi_bufr,mls_nrt_nc,ncep_1bamua_bufr,ncep_acftpfl_bufr,ncep_atms_bufr,ncep_aura_omi_bufr,ncep_avcsam_bufr,ncep_avcspm_bufr,ncep_crisfsr_bufr,ncep_goesfv_bufr,ncep_gpsro_bufr,ncep_mhs_bufr,ncep_mtiasi_bufr,ncep_prep_bufr,ncep_satwnd_bufr,ncep_ssmis_bufr,ncep_tcvitals,npp_ompsnm_bufr,npp_ompslp_nc,n21_ompslp_nc,gmao_mlst_bufr
+> disc_airs_bufr,disc_amsua_bufr,gmao_amsr2_bufr,gmao_gmi_bufr,mls_nrt_nc,ncep_1bamua_bufr,ncep_acftpfl_bufr,ncep_atms_bufr,aura_omieff_nc,ncep_avcsam_bufr,ncep_avcspm_bufr,ncep_crisfsr_bufr,ncep_goesfv_bufr,ncep_gpsro_bufr,ncep_mhs_bufr,ncep_mtiasi_bufr,ncep_prep_bufr,ncep_satwnd_bufr,ncep_ssmis_bufr,ncep_tcvitals,npp_ompsnm_bufr,npp_ompslp_nc,n21_ompslp_nc,gmao_mlst_bufr
 
 CHECKING OBSYSTEM? [2]
 > 1


### PR DESCRIPTION
Minor changes for FPP/FP - certainly non-zero diff. But OMI in particular resolves the issue of the source of OMI and the fact that EMC stopped the FP flavor a couple of days ago  - 21 May 2025.