### PR TITLE
Add 3d-pressure (remove pressure thickness)

### DIFF
--- a/src/Applications/GEOSdas_App/jedi/etc/convertana_geos.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/convertana_geos.yaml
@@ -17,13 +17,15 @@ states:
     datetime: $ISO_STATES_DATE
     filetype: cube sphere history
     provider: geos
+    compute edge pressure from surface pressure: true
+    max allowable geometry difference: 1e-3
     filename: &mybkg $JEDI_CUBED_BKG
     datapath: ./
     state variables: 
     - eastward_wind
     - northward_wind
     - air_temperature
-    - air_pressure_thickness
+    - air_pressure_levels
     - air_pressure_at_surface
     - water_vapor_mixing_ratio_wrt_moist_air
     - cloud_liquid_ice
@@ -64,7 +66,6 @@ states:
       eastward_wind: ua
       northward_wind: va
       air_temperature: t
-      air_pressure_thickness: delp
       water_vapor_mixing_ratio_wrt_moist_air: q
       cloud_liquid_ice: qi
       cloud_liquid_water: ql
@@ -93,6 +94,7 @@ states:
       skin_temperature_at_surface: ts
       eastward_wind_at_surface: u10m
       northward_wind_at_surface: v10m
+      air_pressure_levels: pe
       air_pressure_at_surface: ps
       sea_surface_temperature: ts_found
 #vtype, stype,vfrac,

--- a/src/Applications/GEOSdas_App/jedi/etc/diffstates_geos.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/diffstates_geos.yaml
@@ -21,6 +21,8 @@ state1:
   datetime: $ISO_STATES_DATE
   filetype: cube sphere history
   provider: geos
+  compute edge pressure from surface pressure: true
+  max allowable geometry difference: 1e-3
   datapath: ./ana
   filename: $JEDI_CUBED_ANA
   state variables: &statevars
@@ -34,6 +36,7 @@ state1:
   - snow_water
   - mole_fraction_of_ozone_in_air
   - geopotential_height_times_gravity_at_surface
+  - air_pressure_levels
   - air_pressure_at_surface
   - skin_temperature_at_surface
   field io names: &field_io_names
@@ -47,13 +50,15 @@ state1:
     snow_water: qs
     mole_fraction_of_ozone_in_air: o3ppmv
     geopotential_height_times_gravity_at_surface: phis
+    air_pressure_levels: pe
     air_pressure_at_surface: ps
     skin_temperature_at_surface: ts
-# - delp
 state2:
   datetime: $ISO_STATES_DATE
   filetype: cube sphere history
   provider: geos
+  compute edge pressure from surface pressure: true
+  max allowable geometry difference: 1e-3
   datapath: ./bkg
   filename: $JEDI_CUBED_BKG
   state variables: *statevars

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_3dfgat.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_3dfgat.yaml
@@ -5,6 +5,7 @@ cost function:
   - air_temperature
   - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water
@@ -19,6 +20,8 @@ cost function:
     datetime: $JEDI_ISO_DATE_BEG
     filetype: cube sphere history
     provider: geos
+    compute edge pressure from surface pressure: true
+    max allowable geometry difference: 1e-3
     datapath: ./
     filenames:
     - bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4
@@ -27,7 +30,7 @@ cost function:
     - eastward_wind
     - northward_wind
     - air_temperature
-    - air_pressure_thickness
+    - air_pressure_levels
     - air_pressure_at_surface
     - water_vapor_mixing_ratio_wrt_moist_air
     - cloud_liquid_ice
@@ -69,7 +72,6 @@ cost function:
       eastward_wind: ua
       northward_wind: va
       air_temperature: t
-      air_pressure_thickness: delp
       water_vapor_mixing_ratio_wrt_moist_air: q
       cloud_liquid_ice: qi
       cloud_liquid_water: ql
@@ -98,6 +100,7 @@ cost function:
       skin_temperature_at_surface: ts
       eastward_wind_at_surface: u10m
       northward_wind_at_surface: v10m
+      air_pressure_levels: pe
       air_pressure_at_surface: ps
       sea_surface_temperature: ts_found
 #     mole_fraction_of_carbon_dioxide_in_air: co2
@@ -159,6 +162,8 @@ cost function:
     tstep: PT3H
     filetype: cube sphere history
     provider: geos
+    compute edge pressure from surface pressure: true
+    max allowable geometry difference: 1e-3
     datapath: ./
     filenames:
     - bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4
@@ -193,6 +198,7 @@ variational:
         air_temperature: t
         water_vapor_mixing_ratio_wrt_moist_air: q
         air_pressure_at_surface: ps
+        air_pressure_levels: pe
         cloud_liquid_ice: qi
         cloud_liquid_water: ql
         rain_water: qr

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_3dvar.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_3dvar.yaml
@@ -22,6 +22,7 @@ cost function:
   - air_temperature
   - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water
@@ -36,6 +37,8 @@ cost function:
     datetime: $JEDI_ISO_DATE_ANA
     filetype: cube sphere history
     provider: geos
+    compute edge pressure from surface pressure: true
+    max allowable geometry difference: 1e-3
     datapath: ./
     filenames:
     - bkg.%yyyy%mm%ddT%hh%MM%ssZ.nc4
@@ -44,7 +47,7 @@ cost function:
     - eastward_wind
     - northward_wind
     - air_temperature
-    - air_pressure_thickness
+    - air_pressure_levels
     - air_pressure_at_surface
     - water_vapor_mixing_ratio_wrt_moist_air
     - cloud_liquid_ice
@@ -85,7 +88,6 @@ cost function:
       eastward_wind: ua
       northward_wind: va
       air_temperature: t
-      air_pressure_thickness: delp
       water_vapor_mixing_ratio_wrt_moist_air: q
       cloud_liquid_ice: qi
       cloud_liquid_water: ql
@@ -114,6 +116,7 @@ cost function:
       skin_temperature_at_surface: ts
       eastward_wind_at_surface: u10m
       northward_wind_at_surface: v10m
+      air_pressure_levels: pe
       air_pressure_at_surface: ps
       sea_surface_temperature: ts_found
   background error:

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_hyb3dcenvar.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_hyb3dcenvar.yaml
@@ -5,6 +5,8 @@ cost function:
   - air_temperature
   - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
+  - air_pressure_levels
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water
@@ -24,11 +26,13 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: &statevars
       - eastward_wind
       - northward_wind
       - air_temperature
-      - air_pressure_thickness
+      - air_pressure_levels
       - air_pressure_at_surface
       - water_vapor_mixing_ratio_wrt_moist_air
       - cloud_liquid_ice
@@ -69,7 +73,6 @@ cost function:
       eastward_wind: ua
       northward_wind: va
       air_temperature: t
-      air_pressure_thickness: delp
       water_vapor_mixing_ratio_wrt_moist_air: q
       cloud_liquid_ice: qi
       cloud_liquid_water: ql
@@ -98,6 +101,7 @@ cost function:
       skin_temperature_at_surface: ts
       eastward_wind_at_surface: u10m
       northward_wind_at_surface: v10m
+      air_pressure_levels: pe
       air_pressure_at_surface: ps
       sea_surface_temperature: ts_found
   background error:
@@ -150,6 +154,8 @@ cost function:
 ##     datetime: 2020-12-15T00:00:00Z
 ##     filetype: cube sphere history
 ##     provider: geos
+##     compute edge pressure from surface pressure: true
+##     max allowable geometry difference: 1e-3
 ##     filename: Data/inputs/geos_c90/clim6.nc4
         value: 0.50
 
@@ -161,6 +167,8 @@ cost function:
             - datetime: $JEDI_ISO_DATE_ANA
               filetype: cube sphere history
               provider: geos
+              compute edge pressure from surface pressure: true
+              max allowable geometry difference: 1e-3
               state variables: *anavars
               datapath: ./
               filenames: [mem%mem%/geos.bkg_clcv.%yyyy%mm%dd_%hh%MMz.nc4, fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKGCOV_RESOL.nc4]

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_hyb4dcenvar.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_hyb4dcenvar.yaml
@@ -5,6 +5,7 @@ cost function:
   - air_temperature
   - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water
@@ -24,11 +25,13 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: &statevars
       - eastward_wind
       - northward_wind
       - air_temperature
-      - air_pressure_thickness
+      - air_pressure_levels
       - air_pressure_at_surface
       - water_vapor_mixing_ratio_wrt_moist_air
       - cloud_liquid_ice
@@ -69,7 +72,6 @@ cost function:
       eastward_wind: ua
       northward_wind: va
       air_temperature: t
-      air_pressure_thickness: delp
       water_vapor_mixing_ratio_wrt_moist_air: q
       cloud_liquid_ice: qi
       cloud_liquid_water: ql
@@ -98,6 +100,7 @@ cost function:
       skin_temperature_at_surface: ts
       eastward_wind_at_surface: u10m
       northward_wind_at_surface: v10m
+      air_pressure_levels: pe
       air_pressure_at_surface: ps
       sea_surface_temperature: ts_found
     - datapath: './'
@@ -107,6 +110,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
     - datapath: './'
@@ -116,6 +121,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
     - datapath: './'
@@ -125,6 +132,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
     - datapath: './'
@@ -134,6 +143,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
     - datapath: './'
@@ -143,6 +154,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
     - datapath: './'
@@ -152,6 +165,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
   background error:
@@ -204,6 +219,8 @@ cost function:
 ##     datetime: 2020-12-15T00:00:00Z
 ##     filetype: cube sphere history
 ##     provider: geos
+##     compute edge pressure from surface pressure: true
+##     max allowable geometry difference: 1e-3
 ##     filename: Data/inputs/geos_c90/clim6.nc4
         value: 0.50
 
@@ -215,42 +232,56 @@ cost function:
             - datetime: $JEDI_ISO_DATE_001
               filetype: cube sphere history
               provider: geos
+              compute edge pressure from surface pressure: true
+              max allowable geometry difference: 1e-3
               state variables: *anavars
               datapath: ./
               filenames: [mem%mem%/geos.bkg_clcv.%yyyy%mm%dd_%hh%MMz.nc4, fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKGCOV_RESOL.nc4]
             - datetime: $JEDI_ISO_DATE_002
               filetype: cube sphere history
               provider: geos
+              compute edge pressure from surface pressure: true
+              max allowable geometry difference: 1e-3
               state variables: *anavars
               datapath: ./
               filenames: [mem%mem%/geos.bkg_clcv.%yyyy%mm%dd_%hh%MMz.nc4, fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKGCOV_RESOL.nc4]
             - datetime: $JEDI_ISO_DATE_003
               filetype: cube sphere history
               provider: geos
+              compute edge pressure from surface pressure: true
+              max allowable geometry difference: 1e-3
               state variables: *anavars
               datapath: ./
               filenames: [mem%mem%/geos.bkg_clcv.%yyyy%mm%dd_%hh%MMz.nc4, fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKGCOV_RESOL.nc4]
             - datetime: $JEDI_ISO_DATE_004
               filetype: cube sphere history
               provider: geos
+              compute edge pressure from surface pressure: true
+              max allowable geometry difference: 1e-3
               state variables: *anavars
               datapath: ./
               filenames: [mem%mem%/geos.bkg_clcv.%yyyy%mm%dd_%hh%MMz.nc4, fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKGCOV_RESOL.nc4]
             - datetime: $JEDI_ISO_DATE_005
               filetype: cube sphere history
               provider: geos
+              compute edge pressure from surface pressure: true
+              max allowable geometry difference: 1e-3
               state variables: *anavars
               datapath: ./
               filenames: [mem%mem%/geos.bkg_clcv.%yyyy%mm%dd_%hh%MMz.nc4, fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKGCOV_RESOL.nc4]
             - datetime: $JEDI_ISO_DATE_006
               filetype: cube sphere history
               provider: geos
+              compute edge pressure from surface pressure: true
+              max allowable geometry difference: 1e-3
               state variables: *anavars
               datapath: ./
               filenames: [mem%mem%/geos.bkg_clcv.%yyyy%mm%dd_%hh%MMz.nc4, fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKGCOV_RESOL.nc4]
             - datetime: $JEDI_ISO_DATE_007
               filetype: cube sphere history
               provider: geos
+              compute edge pressure from surface pressure: true
+              max allowable geometry difference: 1e-3
               state variables: *anavars
               datapath: ./
               filenames: [mem%mem%/geos.bkg_clcv.%yyyy%mm%dd_%hh%MMz.nc4, fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKGCOV_RESOL.nc4]
@@ -363,6 +394,8 @@ cost function:
 #       datetime: 2020-12-15T00:00:00Z
 #       filetype: cube sphere history
 #       provider: geos
+#       compute edge pressure from surface pressure: true
+#       max allowable geometry difference: 1e-3
 #       filename: Data/inputs/geos_c90/tropo6.nc4
 #       filename: Data/inputs/geos_c90/ens6.nc4
         value: 0.50

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_hyb4denvar.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_hyb4denvar.yaml
@@ -5,6 +5,7 @@ cost function:
   - air_temperature
   - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water
@@ -24,11 +25,13 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: &statevars
       - eastward_wind
       - northward_wind
       - air_temperature
-      - air_pressure_thickness
+      - air_pressure_levels
       - air_pressure_at_surface
       - water_vapor_mixing_ratio_wrt_moist_air
       - cloud_liquid_ice
@@ -69,7 +72,6 @@ cost function:
         eastward_wind: ua
         northward_wind: va
         air_temperature: t
-        air_pressure_thickness: delp
         water_vapor_mixing_ratio_wrt_moist_air: q
         cloud_liquid_ice: qi
         cloud_liquid_water: ql
@@ -98,6 +100,7 @@ cost function:
         skin_temperature_at_surface: ts
         eastward_wind_at_surface: u10m
         northward_wind_at_surface: v10m
+        air_pressure_levels: pe
         air_pressure_at_surface: ps
         sea_surface_temperature: ts_found
     - datapath: './'
@@ -107,6 +110,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
     - datapath: './'
@@ -116,6 +121,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
     - datapath: './'
@@ -125,6 +132,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
     - datapath: './'
@@ -134,6 +143,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
     - datapath: './'
@@ -143,6 +154,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
     - datapath: './'
@@ -152,6 +165,8 @@ cost function:
       - fv3-jedi/bkg/geos.crtmsrf.@JEDI_BKG_HRES.nc4
       filetype: cube sphere history
       provider: geos
+      compute edge pressure from surface pressure: true
+      max allowable geometry difference: 1e-3
       state variables: *statevars
       field io names: *field_io_names
   background error:

--- a/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
+++ b/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
@@ -133,7 +133,7 @@ sub init {
    if ( $opt_jediroot ) {
         $jediroot = $opt_jediroot;
    } else {
-        $jediroot = "/discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_05292025/build-intel-release";
+        $jediroot = "/discover/nobackup/projects/gmao/advda/swell/JediBundles/fv3_soca_SLES15_06182025/build-intel-release";
    }
 
    if ( $opt_archive ) {


### PR DESCRIPTION
This change - nailed to a more recent version of JEDI (e.g., 18 Jun 2025) - allows for proper handling of the RO operator in UFO; and convergence control. I have shown this (JEDI repo and at Monitoring) to be a desired correction.

This is zero diff to the regular ADAS.