### PR TITLE
Changes in GEOSadas repo to run monthly means jobs with linked inputs

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -61,7 +61,7 @@ GEOS_Util:
 GMAO_perllib:
   local: ./src/Shared/@GMAO_Shared/@GMAO_perllib
   remote: ../GMAO_perllib.git
-  tag: v1.1.0
+  tag: v1.2.0
   develop: main
 
 # When updating the MAPL version, also update the MAPL version in the

--- a/src/Applications/GEOSdas_App/monthly.yyyymm.pl.tmpl
+++ b/src/Applications/GEOSdas_App/monthly.yyyymm.pl.tmpl
@@ -14,12 +14,18 @@
 #    - change file permissions to be executable
 #
 # 2. runtime processing flags:
+#    -prefetch: prefetch inputs before running monthly means (obsolescent)
 #    -means: run monthly means
 #    -plots: run monthly plots
 #    -tar: tar monthly inputs
 #    (see usage() for more complete processing information)
 #
-# 3. To reiterate from Note #1:
+# 3. The separate prefetch job was originally conceived when data were stored
+#    on an archive disk not visible to the compute nodes and which sometimes
+#    required long wait times for data to be de-migrated from tape. Absent
+#    these conditions, there is no need to prefetch data.
+#
+# 4. To reiterate from Note #1:
 #    - The script must be located in the experiment run directory before running
 #    - The yyyymm data date is extracted from the script name.
 #=======================================================================
@@ -55,9 +61,9 @@ use WriteLog qw(chdir_ mkpath_ unlink_ system_);
 
 # global variables
 #-----------------
-my ($meansFLG, $plotsFLG, $radmonFLG, $tarFLG, $finish, $nopush, %doMeans);
+my ($prefetchFLG, $meansFLG, $plotsFLG, $radmonFLG, $tarFLG);
 my ($EXPID, $FVARCH, $FVHOME, $NODEFLG, $PBS_BIN, $PYRADMON);
-my ($account, $listdir);
+my ($account, $listdir, $finish, $nopush, %doMeans);
 my ($mnthlyRC, $numnodes_mm, $numnodes_mp, $plotHISTrc, $qcmd, $rundir);
 my ($script, $siteID, $workdir, $yyyymm, %newrc, %JOBID);
 my ($walltime_cl, $walltime_mm, $walltime_mp, $walltime_pf);
@@ -114,8 +120,9 @@ sub init {
 
     # get runtime parameters
     #-----------------------
-    GetOptions( "means"        => \$meansFLG,
-                "tar"          => \$tarFLG,
+    GetOptions( "prefetch"     => \$prefetchFLG,
+                "means"        => \$meansFLG,
+                "tar!"         => \$tarFLG,
 
                 "plots"        => \$plotsFLG,
                 "finish_plots" => \$finish,
@@ -134,6 +141,12 @@ sub init {
                 "h|help"   => \$help );
     usage() if $help;
 
+    $prefetchFLG = 0 unless $prefetchFLG;
+    $meansFLG = 0 unless $meansFLG;
+    if ($meansFLG) { $tarFLG = 1 unless defined($tarFLG) }
+    if ($prefetchFLG and ! $meansFLG and ! $tarFLG) {
+        usage();
+    }
     if (defined($radmonFLG)) {
         $radmonFLG = 1 if $radmonFLG < 1 or $radmonFLG > 3;
     }
@@ -289,7 +302,7 @@ sub init {
 #=======================================================================
 sub fetch_calc_tar_and_clean {
     my (%opts, $MMWORK, $filestring, $lastFLG);
-    my (@fetchArr, $processflags);
+    my (@filestringArr, $processflags);
     my ($max, $label, $num, $job_tarfile, @list);
     my ($fileToken, $fileTemplate, @parts, %ftype, %htype, $ftype, $htype);
     my (%doFetch, %doTar);
@@ -336,22 +349,22 @@ sub fetch_calc_tar_and_clean {
 
         $processflags = "" unless $processflags;
         if ($meansFLG and $processflags =~ m/M/) {
-            push @fetchArr, $filestring;
+            push @filestringArr, $filestring;
             $doFetch{$filestring} = 1;
             $doMeans{$filestring} = 1;
         }
         if ($tarFLG and $processflags =~ m/T/) {
-            push @fetchArr, $filestring unless $doFetch{$filestring};
+            push @filestringArr, $filestring unless $doFetch{$filestring};
             $doFetch{$filestring} = 1;
             $doTar{$filestring} = 1;
         }
     }
     close MRC;
 
-    # process each filestring in @fetchArr
-    #-------------------------------------
+    # process each filestring in @filestringArr
+    #------------------------------------------
     $lastFLG = 0;
-    foreach $filestring (@fetchArr) {
+    foreach $filestring (@filestringArr) {
         $fileToken = basename($filestring);
         $fileTemplate = token_resolve($fileToken, $yyyymm);
 
@@ -368,11 +381,11 @@ sub fetch_calc_tar_and_clean {
         $opts{"do_tar"} = 1 if $doTar{$filestring};
 
         $opts{"lastFLG"} = 0;
-        $opts{"lastFLG"} = 1 if $filestring eq $fetchArr[-1];
+        $opts{"lastFLG"} = 1 if $filestring eq $filestringArr[-1];
 
-        fetch_inputs(%opts)         if $doFetch{$filestring};
-        calc_monthly_means(%opts)   if $doMeans{$filestring};
-        tar_and_clean_inputs(%opts) if $doFetch{$filestring};
+        if ($prefetchFLG) { fetch_inputs(%opts) if $doFetch{$filestring} }
+        if ($meansFLG) { calc_monthly_means(%opts) if $doMeans{$filestring} }
+        if ($tarFLG) { tar_and_clean_inputs(%opts) if $doFetch{$filestring} }
     }
 
     # tar jobscripts
@@ -467,7 +480,9 @@ sub fetch_inputs {
 
     # no more than two data sets in work directory at a time
     #-------------------------------------------------------
-    @deps = ("tarandclean -2");
+    @deps = ();
+    if ($JOBID{"tarandclean"}) { @deps = ("tarandclean -2") }
+    elsif ($JOBID{"means"})    { @deps = ("means -2") }
     $dependFLG = get_dependFLG(@deps);
 
     # submit job
@@ -485,9 +500,11 @@ sub fetch_inputs {
 # => $ftype: data file type
 # => $htype: data hour type
 # => $do_dmput: flag indicating whether to dmput data input files
+# => $lastFLG: flag indicating whether this is last data collection
 #=======================================================================
 sub calc_monthly_means {
-    my (%opts, $filestring, $ftype, $htype, $do_dmput);
+    my (%opts, $filestring, $ftype, $htype, $do_dmput, $do_tar);
+    my ($lastFLG, $lastindex);
     my ($tmpl, $means_j, $jobname, $outfile, $tasks_per_node);
     my ($job_name, $constraint, $nodes, $time, $output, $per_node);
     my ($vFLG, $processors, %value, @deps, $dependFLG, $cmd);
@@ -500,6 +517,8 @@ sub calc_monthly_means {
     $ftype      = $opts{"ftype"};
     $htype      = $opts{"htype"};
     $do_dmput   = $opts{"do_dmput"};
+    $do_tar     = $opts{"do_tar"};
+    $lastFLG    = $opts{"lastFLG"};
 
     # create monthly_means job script
     #--------------------------------
@@ -539,28 +558,46 @@ sub calc_monthly_means {
     $value{"__TIME__"}       = $time;
     $value{"__ACCOUNT__"}    = $account;
     $value{"__OUTPUT__"}     = $output;
-    $value{"__NODES__"}      = $nodes;
     $value{"__CONSTRAINT__"} = $constraint;
-    $value{"__PER_NODE__"}   = $per_node;
-    $value{"__PROCESSORS__"} = $processors;
 
     $value{"__MONTHLY_PARTITION__"} = $parFLG;
     $value{"__MONTHLY_QOS__"} = $qosFLG;
 
+    $value{"__NODES__"}      = $nodes;
+    $value{"__PER_NODE__"}   = $per_node;
+    $value{"__PROCESSORS__"} = $processors;
+    
     $value{"__FILESTRING__"} = $filestring;
     $value{"__HOURTYPE__"}   = $htype;
     $value{"__YYYYMM__"}     = $yyyymm;
     $value{"__RUNDIR__"}     = $rundir;
     $value{"__WORKDIR__"}    = $workdir;
     $value{"__DO_DMPUT__"}   = $do_dmput;
-    $value{"__DO_SKIP_CHK__"}   = 1;
+    $value{"__DO_TAR__"}     = $do_tar;
+    $value{"__DO_SKIP_CHK__"} = 1;
 
-    replaceLabels($tmpl, $means_j, %value);
-
-    # wait for "fetch" job to complete
+    # determine job dependencies
     #---------------------------------
+    # wait for corresponding  "fetch" job to complete
+    #------------------------------------------------
+    # note: if there are no tarandclean jobs, then the last means job should
+    # wait for all other means jobs to complete before starting, since it will
+    # remove the work directory when it is done. If there are tarandclean jobs
+    # then the last tarandclean job will remove the work directory.
+    #-------------------------------------------------------------------------
     @deps = ("fetch -1");
+    if ($lastFLG and ! $tarFLG) {
+        $lastindex = $#{$JOBID{"means"}};
+        foreach (0..$lastindex) { push @deps, "means $_" }
+    } else {
+        $lastFLG = 0;
+    }
     $dependFLG = get_dependFLG(@deps);
+
+    # these lines moved behind dependencies, since $lastFLG might change
+    #-------------------------------------------------------------------
+    $value{"__LASTFLG__"} = $lastFLG;
+    replaceLabels($tmpl, $means_j, %value);
 
     # submit job
     #-----------
@@ -582,10 +619,10 @@ sub calc_monthly_means {
 # => $lastFLG: flag indicating whether this is last data collection
 #=======================================================================
 sub tar_and_clean_inputs {
-    my (%opts, $filestring, $fileTemplate, $ftype, $do_tar, $lastFLG);
-    my ($tmpl, $tarandclean_j, $jobname, $outfile);
+    my (%opts, $filestring, $fileTemplate, $ftype, $htype, $do_dmput, $do_tar);
+    my ($tmpl, $tarandclean_j, $jobname, $outfile, $lastFLG, $lastindex);
     my ($job_name, $time, $output, $parFLG, $vFLG);
-    my ($constraint);
+    my ($constraint, $fetchFLG);
     my (%value, $walltime, @deps, $dependFLG, $cmd);
 
     # input arguments
@@ -594,6 +631,8 @@ sub tar_and_clean_inputs {
     $filestring   = $opts{"filestring"};
     $fileTemplate = $opts{"fileTemplate"};
     $ftype        = $opts{"ftype"};
+    $htype        = $opts{"htype"};
+    $do_dmput     = $opts{"do_dmput"};
     $do_tar       = $opts{"do_tar"};
     $lastFLG      = $opts{"lastFLG"};
 
@@ -622,6 +661,11 @@ sub tar_and_clean_inputs {
         $vFLG = "-v outfile=$outfile";
     }
 
+    # if neither the prefetch nor means job has run, then fetch inputs
+    #-----------------------------------------------------------------
+    if ($prefetchFLG or $meansFLG) { $fetchFLG = 0 }
+    else                           { $fetchFLG = 1 }
+
     %value = ();
     $value{"__JOB_NAME__"}   = $job_name;
     $value{"__TIME__"}       = $time;
@@ -632,9 +676,12 @@ sub tar_and_clean_inputs {
 
     $value{"__FILESTRING__"}    = $filestring;
     $value{"__FILETEMPLATE__"}  = $fileTemplate;
+    $value{"__HOURTYPE__"}      = $htype;
     $value{"__YYYYMM__"}        = $yyyymm;
+    $value{"__FETCHFLG__"}      = $fetchFLG;
     $value{"__RUNDIR__"}        = $rundir;
     $value{"__WORKDIR__"}       = $workdir;
+    $value{"__DO_DMPUT__"}      = $do_dmput;
     $value{"__DO_TAR__"}        = $do_tar;
     $value{"__LASTFLG__"}       = $lastFLG;
 
@@ -642,11 +689,15 @@ sub tar_and_clean_inputs {
 
     # determine job dependencies
     #--------------------------------------------------------
-    # note: last tarandclean job submitted should be last job
-    # to start, since it will remove work directory when done
+    # note: last tarandclean job should wait for all other
+    # tarandclean jobs to complete before starting, since
+    # it will remove work directory when it is done.
     #--------------------------------------------------------
     @deps = ();
-    if ($lastFLG)              { push @deps, "tarandclean -1" }
+    if ($lastFLG) {
+        $lastindex = $#{$JOBID{"tarandclean"}};
+        foreach (0..$lastindex) { push @deps, "tarandclean $_" }
+    }
     if ($doMeans{$filestring}) { push @deps, "means -1" }
     else                       { push @deps, "fetch -1" }
     $dependFLG = get_dependFLG(@deps);
@@ -664,7 +715,7 @@ sub tar_and_clean_inputs {
 #=======================================================================
 sub archive_monthly_keep_files {
     my ($outfile, $vars, $vFLG, $outFLG, $qFLGs, @deps, $dependFLG);
-    my ($KEEParc_csh, $cmd, $cmd_save);
+    my ($KEEParc_csh, $cmd, $cmd_save, $lastindex);
     my ($constraint,$dummy);
 
     # command flags
@@ -691,10 +742,17 @@ sub archive_monthly_keep_files {
         $qFLGs = "-N MMarc.$yyyymm -l ncpus=1,walltime=$walltime_cl";
     }
 
-    # note: make dependent on last "tarandclean" job, since the
-    # last "means" job submitted might not be the last to complete
-    #-------------------------------------------------------------
-    @deps = ("tarandclean -1");
+    # wait for all means and tarandclean jobs to complete before submitting
+    #----------------------------------------------------------------------
+    @deps = ();
+    if ($JOBID{"tarandclean"}) {
+        $lastindex = $#{$JOBID{"tarandclean"}};
+        foreach (0..$lastindex) { push @deps, "tarandclean $_" }
+    }
+    elsif ($JOBID{"means"}) {
+        $lastindex = $#{$JOBID{"means"}};
+        foreach (0..$lastindex) { push @deps, "means $_" }
+    }
     $dependFLG = get_dependFLG(@deps);
 
     # submit job
@@ -726,7 +784,7 @@ sub archive_monthly_keep_files {
 #=======================================================================
 sub archive_monthly_files {
     my ($outfile, $vars, $vFLG, $outFLG, $qFLGs, @deps, $dependFLG);
-    my ($MPParc_csh, $cmd, $cmd_save);
+    my ($MPParc_csh, $cmd, $cmd_save, $lastindex);
     my ($dummy, $constraint);
 
     # command flags
@@ -754,7 +812,17 @@ sub archive_monthly_files {
         $qFLGs = "-N MPParc.$yyyymm -l ncpus=1,walltime=$walltime_cl";
     }
 
-    @deps = ("tarandclean -1");
+    # wait for all means and tarandclean jobs to complete before submitting
+    #----------------------------------------------------------------------
+    @deps = ();
+    if ($JOBID{"tarandclean"}) {
+        $lastindex = $#{$JOBID{"tarandclean"}};
+        foreach (0..$lastindex) { push @deps, "tarandclean $_" }
+    }
+    elsif ($JOBID{"means"}) {
+        $lastindex = $#{$JOBID{"means"}};
+        foreach (0..$lastindex) { push @deps, "means $_" }
+    }
     $dependFLG = get_dependFLG(@deps);
 
     # submit job
@@ -787,7 +855,7 @@ sub archive_monthly_files {
 sub monthly_plots {
     my ($tmpl, $transfer_csh, $plots_j, $jobname, $outfile);
     my ($job_name, $nodes, $time, $output, $parFLG);
-    my (%value, @deps, $dependFLG, $vFLG, $cmd);
+    my (%value, @deps, $dependFLG, $lastindex, $vFLG, $cmd);
 
     # create plots transfer job script
     #---------------------------------
@@ -864,10 +932,17 @@ sub monthly_plots {
 
     replaceLabels($tmpl, $plots_j, %value);
 
-    # command flags
-    #--------------
+    # wait for all means and tarandclean jobs to complete before submitting
+    #----------------------------------------------------------------------
     @deps = ();
-    @deps = ("tarandclean -1") if $meansFLG;
+    if ($JOBID{"tarandclean"}) {
+        $lastindex = $#{$JOBID{"tarandclean"}};
+        foreach (0..$lastindex) { push @deps, "tarandclean $_" }
+    }
+    elsif ($JOBID{"means"}) {
+        $lastindex = $#{$JOBID{"means"}};
+        foreach (0..$lastindex) { push @deps, "means $_" }
+    }
     $dependFLG = get_dependFLG(@deps);
 
     # submit job
@@ -1058,11 +1133,12 @@ sub get_dependFLG {
         ($jobtype, $index) = split /\s+/;
         die "Error. Unknown jobtype: $jobtype;" unless $valid{$jobtype};
 
-        $jobID = $JOBID{$jobtype}[$index];
-        unless ($IDlist) { $IDlist  =     $jobID if $jobID }
-        else             { $IDlist .= ":".$jobID if $jobID }
+        if ($JOBID{$jobtype}) {
+            $jobID = $JOBID{$jobtype}[$index];
+            unless ($IDlist) { $IDlist  =     $jobID if $jobID }
+            else             { $IDlist .= ":".$jobID if $jobID }
+        }
     }
-
     if ($siteID eq "nccs") {
         $dependFLG = "--dependency=afterany:$IDlist" if $IDlist;
     }
@@ -1120,6 +1196,21 @@ sub qsubW {
 }
 
 #=======================================================================
+# name - dump_JOBID
+# purpose - add call(s) to this sub to dump contents of JOBID hash array
+#           for debug purposes.
+#=======================================================================
+sub dump_JOBID {
+    my ($label);
+    print "\n[DEBUG]\n";
+    foreach $label (keys(%JOBID)) {
+        print "(debug) $label:";
+        foreach (0..$#{$JOBID{$label}}) { print " $JOBID{$label}[$_]" }
+        print "\n";
+    }
+}
+
+#=======================================================================
 # name - usage
 # purpose - print usage information
 #=======================================================================
@@ -1129,8 +1220,13 @@ purpose: calculate means, tar inputs, and/or produce plots for monthly data
 usage: $script [process options] [plot option] [other options]
 
 process options (see Notes below)
+  -prefetch             (obsolescent; see prologue notes) submit separate jobs
+                        to prefetch monthly means inputs for means and/or tar jobs;
+                        the -prefetch flag makes no sense without the -means or
+                        -tar flag
   -means                calculate monthly means
-  -tar                  tar input files
+  -(no)tar              tar input files; by default, input files will be tarred
+                        if -means flag is given, unless -notar flag is also given
 
   -plots                produce monthly plots from monthly means
   -finish_plots         finish monthly plots job which stopped before completion

--- a/src/Applications/GEOSdas_App/monthly_means.j.tmpl
+++ b/src/Applications/GEOSdas_App/monthly_means.j.tmpl
@@ -34,6 +34,8 @@ set yyyymm     = __YYYYMM__
 set rundir     = __RUNDIR__
 set workdir    = __WORKDIR__
 set do_dmput   = __DO_DMPUT__
+set do_tar     = __DO_TAR__
+set lastFLG    = __LASTFLG__
 unset echo
 echo
 
@@ -42,6 +44,9 @@ if ("H$htype" != "H") set hourtypeFLG = "-T $htype"
 
 set dmputFLG = ""
 if ($do_dmput) set dmputFLG = "-p"
+ 
+set tarFLG = ""
+if ($do_tar) set tarFLG = "-t"
  
 # set job environment variables
 #------------------------------
@@ -78,7 +83,7 @@ $ERR -E 0 -D "$EXPID NOTICE: Monthly Means job has begun processing for $yyyymm"
 
 # command to calculate monthly means
 #-----------------------------------
-monthly_means.pl -L -l -v $dmputFLG $monitorlocFLG \
+monthly_means.pl -l -v $dmputFLG $tarFLG $monitorlocFLG \
    -H $FVHOME \
    -R $FVROOT \
    -D $yyyymm \
@@ -91,6 +96,13 @@ monthly_means.pl -L -l -v $dmputFLG $monitorlocFLG \
 if ( $exit_status ) then
     $ERR -E 5 -D "$EXPID FATAL ERROR: Monthly Means job has FAILED for $yyyymm"
     exit 1
+endif
+
+# if this is the last ftype and no tar jobs follow, then remove workdir
+#----------------------------------------------------------------------
+if ($lastFLG) then
+    cd $rundir
+    \rm -rf $workdir
 endif
 
 # rename output file for successful run

--- a/src/Applications/GEOSdas_App/monthly_means.pl
+++ b/src/Applications/GEOSdas_App/monthly_means.pl
@@ -72,9 +72,9 @@ use lib @SEARCH_PATH;
 # global variables
 #-----------------
 my ($archive, $date, $delete, $dmget_bin, $do_dmput, $do_tar, $endday, $expid);
-my ($fileToken, $ftype, $hm, $htype, $ignore, $links, $localflg, $local_dir);
-my ($monitorloc, $monthly_means_x, $nodiurnal, $num_days, $prefetch, $rcfile);
-my ($remote_dir, $remote_machine, $remote_user, $run_config, $silo_dir);
+my ($fileToken, $ftype, $hm, $htype, $ignore, $links, $localflg);
+my ($local_dir, $monitorloc, $monthly_means_x, $nodiurnal, $num_days, $prefetch);
+my ($rcfile, $remote_dir, $remote_machine, $remote_user, $run_config, $silo_dir);
 my ($silo_work, $script, $startday, @times, $verbose, $workdir, $yyyymm);
 my (@mean_files, @remote_file_list, @remove);
 
@@ -87,7 +87,7 @@ my (@mean_files, @remote_file_list, @remove);
     system("date"); print "\n";
 
     init();
-    fetch_inputs();
+    check_or_fetch_inputs();
     calculate_means() unless $prefetch;
 
     if ($prefetch) { $op = "PREFETCH"    }
@@ -277,17 +277,18 @@ sub get_hours_HIST {
 }
 
 #=======================================================================
-# name - fetch_inputs
-# purpose - make input files local prior to calculating monthly means
-#           and/or tarring
+# name - check_or_fetch_inputs
+# purpose - check for input files needed for monthly means or tarrting,
+#           and make them available in the workdir, if they are not there.
 #=======================================================================
-sub fetch_inputs {
+sub check_or_fetch_inputs {
     use File::Basename qw(basename);
     use File::Compare qw(compare);
     use Remote_utils qw(rm_remote_file);
     use Sys::Hostname ("hostname");
 
     my ($stem, $full_tarfile, $partial_tarfile, $check_inputs);
+    my ($currday, $filename, $time, $missing_inputs);
     my ($IN_TAR_INFO, $OUT_TAR_INFO);
 
     $stem = "$expid.$ftype.$yyyymm";
@@ -333,10 +334,57 @@ sub fetch_inputs {
     if ($check_inputs) {
         fetch_individual_inputs($OUT_TAR_INFO);
     }
+
+    # final check for files
+    #----------------------
+    $missing_inputs = 0;
+    foreach $currday ($startday..$endday) {
+        foreach $time (@times) {
+            $filename = token_resolve($fileToken, $currday, $time);
+            if (-f $filename and -s $filename) {
+                push @mean_files, $filename;
+            }
+            elsif ($ignore) {
+                warn "WARNING: $filename cannot be found\n";
+                $missing_inputs++;
+            }
+            else {
+                wrapup(1, $delete, "FATAL ERROR: $filename cannot be found");
+            }
+        }
+    }
+
+    # after fetch, store info in workdir files for tar job
+    #-----------------------------------------------------
+    # write info for OUT_TAR_INFO file
+    #---------------------------------
+    if ($do_tar) {
+        open OFO, "> $OUT_TAR_INFO" or die "Error opening $OUT_TAR_INFO: $!";
+        print OFO "$local_dir\n";
+        print OFO "$remote_dir\n";
+    }
+    if ($missing_inputs) {
+        if (@mean_files) {
+            print OFO "partial\n" if $do_tar;
+            print "\n$missing_inputs $ftype $yyyymm inputs are missing.\n";
+            print "Will create partial tarfile for $ftype inputs.\n" if $do_tar;
+        } else {
+            print OFO "empty\n" if $do_tar;
+            print "\nNo $ftype $yyyymm inputs were found.\n";
+            print "No tarfile will be created for $ftype inputs.\n" if $do_tar;
+            wrapup(1, $delete, "FATAL ERROR: no $ftype inputs were found");
+        }
+    }
+    else {
+        print OFO "full\n" if $do_tar;
+        print "\nAll $ftype $yyyymm inputs were found.\n";
+        print "Will create full tarfile for $ftype inputs.\n" if $do_tar;
+    }
+    close OFO if $do_tar;
 }
 
 #=======================================================================
-# name - get_files_from_tarfile
+# name - get_inputs_from_tarfile
 # purpose - look for archived tarfile and if found, then retrieve it,
 #           untar it, and then remove it
 #
@@ -385,7 +433,7 @@ sub fetch_individual_inputs {
     use Manipulate_time qw(token_resolve);
     use Remote_utils qw(rdmget rget);
     my ($currday, $filename, $full_local_host_name, $host, $local_ref);
-    my ($local_tarfile, $missing_inputs, $rc, $rget_rc, $rdmget_rc);
+    my ($local_tarfile, $rc, $rget_rc, $rdmget_rc);
     my ($remote_file, $remote_ref, $time, $times_addr, $try);
     my (%opts, $OUT_TAR_INFO);
 
@@ -405,7 +453,8 @@ sub fetch_individual_inputs {
             #--------------------------------
             unless (-f $filename and -s $filename) {
                 print "$filename not found in work directory\n" if $verbose;
-                wrapup(1, $delete, "Running $script failed missing $filename.") if $silo_work;
+                wrapup(1, $delete, "Running $script failed missing $filename.")
+                    if $silo_work;
 
                 # look for file in stage directory
                 #---------------------------------
@@ -415,9 +464,11 @@ sub fetch_individual_inputs {
                     # create symlink
                     #---------------
                     if ($links) {
-                        print "linking $local_dir/$filename to $filename\n" if $verbose;
+                        print "linking $local_dir/$filename to $filename\n"
+                            if $verbose;
                         $rc = symlink "$local_dir/$filename", $filename;
-                        wrapup(1, $delete, "Cannot create symbolic link to $filename") unless $rc;
+                        wrapup(1, $delete, "Cannot create symbolic link to $filename")
+                            unless $rc;
                     }
 
                     # or rget to work dir
@@ -474,6 +525,7 @@ sub fetch_individual_inputs {
         unless ($silo_work) {
             %opts = ();
             $opts{"debug"} = $verbose if $verbose;
+            $opts{"links"} = 1 if $links;
             $opts{"run_config"} = $run_config;
             $opts{"preserve"} = 1;
 
@@ -487,7 +539,6 @@ sub fetch_individual_inputs {
 
                     if ($ignore) {
                         warn "WARNING: Cannot acquire $remote_file\n";
-                        $missing_inputs++;
                         last;
                     }
 
@@ -500,55 +551,6 @@ sub fetch_individual_inputs {
                 }
             }
         }
-    }
-
-    # final check for files
-    #----------------------
-    foreach $currday ($startday..$endday) {
-        foreach $time (@times) {
-            $filename = token_resolve($fileToken, $currday, $time);
-            if (-f $filename and -s $filename) {
-                push @mean_files, $filename;
-            }
-            elsif ($ignore) {
-                warn "WARNING: $filename cannot be found\n";
-                $missing_inputs++;
-            }
-            else {
-                wrapup(1, $delete, "FATAL ERROR: $filename cannot be found");
-            }
-        }
-    }
-
-    # after prefetch, store info in workdir files for tar job
-    #--------------------------------------------------------
-    if ($prefetch) {
-
-        # write info for output tarfile
-        #------------------------------
-        if ($do_tar) {
-            open OFO, "> $OUT_TAR_INFO" or die "Error opening $OUT_TAR_INFO: $!";
-            print OFO "$local_dir\n";
-            print OFO "$remote_dir\n";
-        }
-        if ($missing_inputs) {
-            if (@mean_files) {
-                print OFO "partial\n" if $do_tar;
-                print "\n$missing_inputs $ftype $yyyymm inputs are missing.\n";
-                print "Will create partial tarfile for $ftype inputs.\n" if $do_tar;
-            } else {
-                print OFO "empty\n" if $do_tar;
-                print "\nNo $ftype $yyyymm inputs were found.\n";
-                print "No tarfile will be created for $ftype inputs.\n" if $do_tar;
-                wrapup(1, $delete, "FATAL ERROR: no $ftype inputs were found");
-            }
-        }
-        else {
-            print OFO "full\n" if $do_tar;
-            print "\nAll $ftype $yyyymm inputs were found.\n";
-            print "Will create full tarfile for $ftype inputs.\n" if $do_tar;
-        }
-        close OFO if $do_tar;
     }
 }
 
@@ -768,11 +770,13 @@ OPTIONS
  -M time_ave.x Optional binary to compute monthly means. Default is FVROOT/bin/time_ave.x
  -m mon_loc    Optional remote location to distribute means files for operational
  -nd           Do not produce diurnal means.
- -prefetch     Fetch files but do not calculate monthly means
+ -prefetch     Fetch inputs with separate job; do not calculate monthly means
  -R FVROOT     The installation directory of the fvDAS software. If not specified,
                then script will attempt to get the value from FVROOT environment variable.
  -r run_config Run_Config file for file transfer options if not DEFAULT
  -S SILO_DIR   If silo is supplied with -S all work is done on files in situ
+ -T htype      The collection hour type, needed for fetch
+ -t            Flag to write, during fetch, workdir files needed later for tarring
  -v            Flag to enable verbose output to STDOUT
  -w workdir    User defined work space for monthly processing.
 

--- a/src/Applications/GEOSdas_App/monthly_prefetch.j.tmpl
+++ b/src/Applications/GEOSdas_App/monthly_prefetch.j.tmpl
@@ -51,7 +51,7 @@ chdir $workdir
 
 # command to prefetch inputs
 #---------------------------
-monthly_means.pl -l -prefetch -v $dmputFLG $tarFLG $ignoreFLG \
+monthly_means.pl -prefetch -v $dmputFLG $tarFLG $ignoreFLG \
    -H $FVHOME \
    -R $FVROOT \
    -D $yyyymm \

--- a/src/Applications/GEOSdas_App/monthly_tarandclean.j.tmpl
+++ b/src/Applications/GEOSdas_App/monthly_tarandclean.j.tmpl
@@ -29,13 +29,58 @@ endif
 set echo
 set filestring   = __FILESTRING__
 set fileTemplate = "__FILETEMPLATE__"
+set htype        = __HOURTYPE__
 set yyyymm       = __YYYYMM__
+set fetchFLG     = __FETCHFLG__
 set rundir       = __RUNDIR__
 set workdir      = __WORKDIR__
+set do_dmput     = __DO_DMPUT__
 set do_tar       = __DO_TAR__
 set lastFLG      = __LASTFLG__
 unset echo
 echo
+
+# command to fetch inputs, if necessary
+#--------------------------------------
+if ($fetchFLG) then
+
+    set ignoreFLG = ""
+    if ($do_tar) set ignoreFLG = "-i"
+
+    set hourtypeFLG = ""
+    if ("H$htype" != "H") set hourtypeFLG = "-T $htype"
+
+    set dmputFLG = ""
+    if ($do_dmput) set dmputFLG = "-p"
+
+    set tarFLG = ""
+    if ($do_tar) set tarFLG = "-t"
+
+    # set job environment variables
+    #------------------------------
+    source $rundir/FVDAS_Run_Config
+    set path = ( $rundir $FVROOT/bin $BASEDIR/$ARCH/bin $path )
+
+    set echo
+    chdir $workdir
+
+    # prefetch inputs
+    #----------------
+    monthly_means.pl -l -prefetch -v $dmputFLG $tarFLG $ignoreFLG \
+       -H $FVHOME \
+       -R $FVROOT \
+       -D $yyyymm \
+       -f $filestring $hourtypeFLG \
+       -w $workdir
+    @ exit_status = $status
+
+    # check status
+    #-------------
+    if ( $exit_status ) then
+        $ERR -E 5 -D "$EXPID FATAL ERROR: Monthly Means fetch job has FAILED for $yyyymm"
+        exit 1
+    endif
+endif
 
 # set job environment variables
 #------------------------------
@@ -170,7 +215,7 @@ if ($do_tar) then
 
     # tar workdir inputs
     #-------------------
-    tar cf $output_tarfile $workdir_inputs
+    tar cfh $output_tarfile $workdir_inputs
     if ($status) then
         echo " Error while creating tarfile, $output_tarfile"
         exit 96
@@ -178,7 +223,7 @@ if ($do_tar) then
 
     # check output tarfile
     #---------------------
-    tar df $output_tarfile
+    tar dfh $output_tarfile
     if ($status) then
         echo " Error. tarfile check failed for $output_tarfile"
         exit 97
@@ -208,7 +253,7 @@ endif
 #-----------------------------------------------
 if ($lastFLG) then
     cd $rundir
-    \rm -r $workdir
+    \rm -rf $workdir
 endif
 
 # rename output file for successful run

--- a/src/Applications/GEOSdas_App/testsuites/runjob.pl
+++ b/src/Applications/GEOSdas_App/testsuites/runjob.pl
@@ -850,8 +850,7 @@ sub run_fvsetup {
 
     # check for previous use of expid
     #--------------------------------
-    if ($nocheck) { $dflt = "n" }
-    else          { $dflt = "y" }
+    $dflt = "n";
     $ans = query("\nCheck for previous use of expid (y/n)?", $dflt);
     unless (neg($ans)) {
         print "\n" ."="x65 ."\n";


### PR DESCRIPTION
* monthly.yyyymm.pl.tmpl
  - added -prefetch flag to prefetch inputs as a separate job
  - modified to tar automatically with -means flag, unless -notar flag is given
  - tightened the logic for setting dependFLG for job submittal
  - remove work directory after last means job, if there are no tarandclean jobs
  - changes necessary for tarandclean jobs to do fetch if necessary
  - added sub dump_JOBID to help debugging job dependencies
* monthly_means.j.tmpl
  - added tarFLG to write, during fetch, files needed for tarring
  - added lastFLG to tell means job to clean workdir if no tarandclean job follows
* monthly_means.pl
  - added links flag when calling rget to link inputs if available locally
  - moved final file check to more central location
* monthly_prefetch.j.tmpl
  - removed links flag for separate prefetch jobs; these inputs will be copied, not linked
* monthly_tarandclean.j.tmpl
  - added code to fetch inputs if not already fetched by fetch or means job
  - added ‘h’ flag to tar commands to work with linked files
* testsuites/runjob.pl
  - change “Check for previous use of expid” default from “y” to “n”

Closes #382

~Contigent on PR #3 in GMAO_perllib repo.~ GMAO_perllib v1.2.0 released.