### PR TITLE
Feature/update for viirs da

### DIFF
--- a/src/Applications/GAAS_App/CMakeLists.txt
+++ b/src/Applications/GAAS_App/CMakeLists.txt
@@ -13,6 +13,7 @@ esma_add_library(${this}
   SRCS ${SRCS}
   DEPENDENCIES GMAO_psas GMAO_ods GMAO_hermes Chem_Base)
 
+target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
 
 ecbuild_add_executable(TARGET ana_aod.x SOURCES ana_aod.F LIBS ${this} GMAO_gfio_r4 Chem_Base Chem_Shared) 
 ecbuild_add_executable(TARGET mpana_aod.x SOURCES mpana_aod.F90 LIBS ${this} GMAO_gfio_r4 Chem_Base Chem_Shared) 

--- a/src/Applications/GAAS_App/ana.rc.tmpl
+++ b/src/Applications/GAAS_App/ana.rc.tmpl
@@ -37,6 +37,10 @@ ODS_files::
 #___AQUA___${FVWORK}/nnr_003.MYD04_L2a.ocean.%y4%m2%d2_%h200z.ods
 #___AQUA___${FVWORK}/nnr_003.MYD04_L2a.deep.%y4%m2%d2_%h200z.ods
 
+#___NOAA20___${FVWORK}/nnr_003._L2a.land.%y4%m2%d2_%h200z.ods
+#___NOAA20___${FVWORK}/nnr_003._L2a.ocean.%y4%m2%d2_%h200z.ods
+#___NOAA20___${FVWORK}/nnr_003._L2a.deep.%y4%m2%d2_%h200z.ods
+
 #___MISR___${FVWORK}/misr_F12_0022.bright_tc8.obs.%y4%m2%d2.ods
 
 #___AERONET___${FVWORK}/aeronet.obs.%y4%m2%d2_%h2z.ods

--- a/src/Applications/GAAS_App/ana.rc.tmpl
+++ b/src/Applications/GAAS_App/ana.rc.tmpl
@@ -37,13 +37,21 @@ ODS_files::
 #___AQUA___${FVWORK}/nnr_003.MYD04_L2a.ocean.%y4%m2%d2_%h200z.ods
 #___AQUA___${FVWORK}/nnr_003.MYD04_L2a.deep.%y4%m2%d2_%h200z.ods
 
-#___NOAA20___${FVWORK}/nnr_003._L2a.land.%y4%m2%d2_%h200z.ods
-#___NOAA20___${FVWORK}/nnr_003._L2a.ocean.%y4%m2%d2_%h200z.ods
-#___NOAA20___${FVWORK}/nnr_003._L2a.deep.%y4%m2%d2_%h200z.ods
+#___NOAA20___${FVWORK}/nnr_001.NOAA20_L2a.dt_land.%y4%m2%d2_%h200z.ods
+#___NOAA20___${FVWORK}/nnr_001.NOAA20_L2a.dt_ocean.%y4%m2%d2_%h200z.ods
+#___NOAA20___${FVWORK}/nnr_001.NOAA20_L2a.db_deep.%y4%m2%d2_%h200z.ods
+
+
+#___SNPP___${FVWORK}/nnr_001._L2a.land.%y4%m2%d2_%h200z.ods
+#___SNPP___${FVWORK}/nnr_001._L2a.ocean.%y4%m2%d2_%h200z.ods
+#___SNPP___${FVWORK}/nnr_001._L2a.deep.%y4%m2%d2_%h200z.ods
+
 
 #___MISR___${FVWORK}/misr_F12_0022.bright_tc8.obs.%y4%m2%d2.ods
 
 #___AERONET___${FVWORK}/aeronet.obs.%y4%m2%d2_%h2z.ods
+
+#___LUNAR_AERONET___${FVWORK}/aeronet.obs.%y4%m2%d2_%h2z.ods
 
 # Passive data
 #/nobackup/3/PARASOL/Level2/ODS/Y%y4/M%m2/PARASOL_L2.aero_tc8.obs.%y4%m2%d2.ods

--- a/src/Applications/GAAS_App/ana.rc.tmpl
+++ b/src/Applications/GAAS_App/ana.rc.tmpl
@@ -42,11 +42,6 @@ ODS_files::
 #___NOAA20___${FVWORK}/nnr_001.NOAA20_L2a.db_deep.%y4%m2%d2_%h200z.ods
 
 
-#___SNPP___${FVWORK}/nnr_001._L2a.land.%y4%m2%d2_%h200z.ods
-#___SNPP___${FVWORK}/nnr_001._L2a.ocean.%y4%m2%d2_%h200z.ods
-#___SNPP___${FVWORK}/nnr_001._L2a.deep.%y4%m2%d2_%h200z.ods
-
-
 #___MISR___${FVWORK}/misr_F12_0022.bright_tc8.obs.%y4%m2%d2.ods
 
 #___AERONET___${FVWORK}/aeronet.obs.%y4%m2%d2_%h2z.ods

--- a/src/Applications/GAAS_App/m_sqc.F90
+++ b/src/Applications/GAAS_App/m_sqc.F90
@@ -148,7 +148,7 @@
 !
 !  15May2002  Dee       Created this module from psas_qc.f version 1.61
 !  31Mar2003 (Dee/Rukh) Minor changes to the buddy check
-!  13Oct2020 (Todling)  Store sigO in xvec
+!  13Oct2020 (Todling)  Store sigO in xvec!
 !
 !EOP
 !-------------------------------------------------------------------------
@@ -801,7 +801,7 @@
               ktPSAS(np) = kta
          end if
       end do
-
+      
 !     Move those data up...
 !     ---------------------
       nmoved = 0
@@ -1267,6 +1267,7 @@
 !     Index vector for sorts (cannot be allocatable because of OMP)
 !     -------------------------------------------------------------
       integer indx(nobs)
+      integer, allocatable :: indx2(:)
 
 !     List of suspect observations
 !     ----------------------------
@@ -1275,8 +1276,9 @@
 
 !     List of buddies
 !     ---------------
-      integer :: ki_buddy(nobs) ! index of buddy
-      real*8    :: wt_buddy(nobs) ! weight of buddy
+      integer, allocatable :: ki_buddy(:) ! index of buddy
+      real*8, allocatable  :: wt_buddy(:) ! weight of buddy
+      real, allocatable :: mysep(:,:)
 
 !     Suspect and reaccept flags
 !     --------------------------
@@ -1304,7 +1306,7 @@
       integer   rc, iter, ireg, ibeg, iend, ilen, i, is, ib, ibb, j
       integer   kis, kts, krs, niter
       integer   maxreg                ! number of PSAS regions
-      real*8      tol2, exponent, scgain
+      real*8      tol2, myexponent, scgain
 
       real*8      dist2, z_dist2
 
@@ -1448,16 +1450,37 @@
                                ' with ', n_susp, ' suspect observations'
 
          n_reacc = 0
+         allocate(mysep(n_susp, maxreg))
+
+         !!!$omp parallel do default(none) private(is, krs) shared(n_susp, maxreg, kr_susp, partition, mysep)
+         do is = 1, n_susp
+            krs = kr_susp(is)
+            do ireg = 1, maxreg
+               mysep(is,ireg) = Separation(GetRegion(ireg,partition),GetRegion(krs,partition),SEPANG_MIN)
+            end do
+         end do
+         !!!$omp end parallel do
+
 
 !$omp  parallel do                                                &
-!$omp  default(shared),                                           &
-!$omp  private(is,kis,kts,krs,nbuddy,ireg,ibeg,iend,i,exponent,   &
-!$omp          scgain,ki_buddy,wt_buddy,indx,accum_del,accum_de2, &
-!$omp          accum_wgt,accum_var,ib,ibb,del_star,alpha,tol2),   &
-!$omp  reduction(+:n_reacc)
+!$omp& schedule(dynamic)                                         & 
+!$omp&  default(none)                                           &
+!$omp&  firstprivate(nobs)                                      &
+!$omp&  private(lvs,is,kis,kts,krs,nbuddy,ireg,ibeg,iend,i,myexponent,   &
+!$omp&          scgain,accum_del,accum_de2, ki_buddy, wt_buddy, indx2,&
+!$omp&          accum_wgt,accum_var,ib,ibb,del_star,alpha,tol2)   &
+!$omp&  shared(n_susp, ki_susp, kt, kr_susp, lev, maxreg, &
+!$omp&         ireglen, seplim, iregbeg, single_level, issuspect, &
+!$omp&         qcx, xobs, yobs, zobs, ls_h, ls_v, search_rad, &
+!$omp&         varF, VarO, nbuddy_max, OmF, nstar, tau_buddy, reaccept,mysep) &
+!$omp&  reduction(+:n_reacc)
+
 
          do is = 1, n_susp      ! for each suspect obs
-
+            allocate(ki_buddy(nobs))
+            allocate(wt_buddy(nobs))
+            allocate(indx2(nobs))
+            
             kis = ki_susp(is)   ! this suspect's index
             kts = kt(kis)       ! this suspect's kt
             krs = kr_susp(is)   ! this suspect's region
@@ -1468,9 +1491,8 @@
             nbuddy = 0
             do ireg = 1, maxreg
 
-               if ((Separation(GetRegion(ireg,partition),GetRegion(krs,partition),SEPANG_MIN) <= seplim) &
+                if ( (mysep(is,ireg) <= seplim) &
                     .and. (ireglen(ireg)   >0     ) ) then  ! nearby region with data
-
                   ibeg = iregbeg(ireg)
                   iend = ibeg + ireglen(ireg) - 1
 
@@ -1484,15 +1506,15 @@
                      if ( .not. issuspect(i) .AND. qcx(i)==0 .AND.  &
                                                   kt(i)==kts) then
 
-                        exponent = dist2(kis,i)/ls_h(kts)**2
+                       myexponent = dist2(kis,i)/ls_h(kts)**2
 
                         if ( ls_v(kts)>tol_rel ) then     ! upper-air data
-                             exponent = exponent + z_dist2(kis,i)/ls_v(kts)**2
+                             myexponent = myexponent + z_dist2(kis,i)/ls_v(kts)**2
                         end if
 
                         ! only if not too far (search_rad length scales):
 
-                        if ( exponent<search_rad**2 ) then
+                        if ( myexponent<search_rad**2 ) then
 
                         ! found a candidate buddy:
 
@@ -1502,7 +1524,7 @@
                         ! associate weight with this candidate:
 
                              scgain = varF(i) / (varF(i) + varO(i))
-                             wt_buddy(nbuddy) =  scgain * exp(-0.5*exponent)
+                             wt_buddy(nbuddy) =  scgain * exp(-0.5*myexponent)
 
                         end if      ! not too far
 
@@ -1518,9 +1540,9 @@
 
 !              Find the best buddies
 !              ---------------------
-               call IndexSet  ( nbuddy, indx )
-               call IndexSort ( nbuddy, indx, wt_buddy, descend=.true. )
-
+               
+               call IndexSet  ( nbuddy, indx2 )
+               call IndexSort ( nbuddy, indx2, wt_buddy, descend=.true. )
                nbuddy = min(nbuddy, nbuddy_max)      ! pick highest weights
 
 !              Do buddy check
@@ -1532,14 +1554,13 @@
 
                do ib = 1, nbuddy       ! accumulate weights, variances, etc.
 
-                  ibb = indx(ib)       ! index in ki_buddy of best buddy
+                  ibb = indx2(ib)       ! index in ki_buddy of best buddy
                   i = ki_buddy(ibb)    ! index in OmF of best buddy
 
                   accum_del = accum_del + OmF(i) * wt_buddy(ibb)
                   accum_wgt = accum_wgt + wt_buddy(ibb)
                   accum_de2 = accum_de2 + (OmF(i))**2
                   accum_var = accum_var + varO(i) + varF(i)
-
                end do
 
                del_star = sngl(accum_del/accum_wgt)    ! prediction
@@ -1560,10 +1581,15 @@
 
             end if
 
+            deallocate(indx2)
+            deallocate(ki_buddy)
+            deallocate(wt_buddy)
+
          end do
 
 !$omp end parallel do
 
+         deallocate(mysep)
          if (verbose) then
              write(stdout,'(2a,i8,a,i2)') myname, ': ',   &
                      n_reacc,' observations reaccepted after iteration', iter
@@ -1629,7 +1655,6 @@
              write(stderr,'(2a)') myname,': allocate() error'
              call die(myname)
          end if
-
 !        Compute iregn from (x,y,z)
 !        -------------------------
          call XYZ2REG ( nobs, xobs, yobs, zobs, kr, partition )
@@ -1644,9 +1669,9 @@
          zobs = zobs( (/ (indx(i), i=1,nobs) /) )
          varF = varF( (/ (indx(i), i=1,nobs) /) )
          varO = varO( (/ (indx(i), i=1,nobs) /) )
-
+         
 !        Also re-sort local arrays
-!        -------------------------
+!       -------------------------- 
          lon = lon( (/ (indx(i), i=1,nobs) /) )
          lat = lat( (/ (indx(i), i=1,nobs) /) )
          OmF = OmF( (/ (indx(i), i=1,nobs) /) )

--- a/src/Applications/GAAS_App/psas.rc
+++ b/src/Applications/GAAS_App/psas.rc
@@ -129,17 +129,18 @@ DataSourceTable::
   320  MYDD        -100  MODIS/AQUA-Land (Deep Blue)
   323  ANET        -100  AERONET
   324  AVHRR       -100  AVHRR NNR Retrievals
-  333  VSNPPDBL    -100  VIIRS SNPP Deep Blue Land
-  334  VSNPPDBO    -100  VIIRS SNPP Deep Blue Ocean
   335  VSNPPDBD    -100  VIIRS SNPP Deep Blue Deep
   336  VSNPPDTL    -100  VIIRS SNPP Dark Target Land
   337  VSNPPDTO    -100  VIIRS SNPP DARK Target Ocean
-  338      -100  VIIRS NOAA20 Deep Blue LAND
-  339      -100  VIIRS NOAA20 Deep Blue OCEAN
-  340  VN20DBD    -100  VIIRS NOAA20 Deep Blue DEEP
-  341  VN20DTL    -100  VIIRS NOAA20 Dark Target LAND
-  342  VN20DTO    -100  VIIRS NOAA20 Dark Target OCEAN
-  343      -100  Lunar Aeronet  
+  338  VN20DBL     -100  VIIRS NOAA20 Deep Blue LAND
+  339  VN20DBO     -100  VIIRS NOAA20 Deep Blue OCEAN
+  340  VN20DBD     -100  VIIRS NOAA20 Deep Blue DEEP
+  341  VN20DTL     -100  VIIRS NOAA20 Dark Target LAND
+  342  VN20DTO     -100  VIIRS NOAA20 Dark Target OCEAN
+  343  LANET       -100  Lunar Aeronet  
+  344  VN21DTL     -100  VIIRS NOAA21 Dark Target LAND
+  345  VN21DTO     -100  VIIRS NOAA21 Dark Target OCEAN
+  346  VN21DBD     -100  VIIRS NOAA21 Deep Blue DEEP
 
 ::      # End of DataSourceTable
 
@@ -217,16 +218,8 @@ ObsErr*AVHRR::   # kx = 324 (like MYDO)
   q_UprAir.u  0.22   0.21   0.20   0.19 
 ::
 
-ObsErr*VSNPPDBO::   # kx = 334
-  q_UprAir.u  0.19   0.19   0.18   0.18
-::
-
-ObsErr*VSNPPDBL::   # kx = 333
-  q_UprAir.u  0.19   0.19   0.18   0.18
-::
-
 ObsErr*VSNPPDBD::   # kx = 335
-  q_UprAir.u  0.19   0.19   0.18   0.18
+  q_UprAir.u  0.22   0.21   0.20   0.19
 ::
 
 ObsErr*VSNPPDTO::   # kx = 336
@@ -237,7 +230,7 @@ ObsErr*VSNPPDTL::   # kx = 337
   q_UprAir.u  0.19   0.19   0.18   0.18
 ::
 
-ObsErr*VN20DBD::   # kx = 340
+ObsErr*VN20DTL::   # kx = 341
   q_UprAir.u  0.19   0.19   0.18   0.18
 ::
 
@@ -245,9 +238,26 @@ ObsErr*VN20DTO::   # kx = 342
   q_UprAir.u  0.19   0.19   0.18   0.18
 ::
 
-ObsErr*VN20DTL::   # kx = 341
+ObsErr*VN20DBD::   # kx = 340
+  q_UprAir.u  0.22   0.21   0.20   0.19
+::
+
+ObsErr*VN21DTL::   # kx = 344
   q_UprAir.u  0.19   0.19   0.18   0.18
 ::
+
+ObsErr*VN21DTO::   # kx = 345
+  q_UprAir.u  0.19   0.19   0.18   0.18
+::
+
+ObsErr*VN21DBD::   # kx = 346
+  q_UprAir.u  0.22   0.21   0.20   0.19
+::
+
+ObsErr*LANET::   # kx = 343  -- same as ANET for now
+  q_UprAir.u  0.22   0.21   0.20   0.19 
+::
+
 #...............................................................................
 
 #              --------------------------------------------------

--- a/src/Applications/GAAS_App/psas.rc
+++ b/src/Applications/GAAS_App/psas.rc
@@ -129,6 +129,17 @@ DataSourceTable::
   320  MYDD        -100  MODIS/AQUA-Land (Deep Blue)
   323  ANET        -100  AERONET
   324  AVHRR       -100  AVHRR NNR Retrievals
+  333  VSNPPDBL    -100  VIIRS SNPP Deep Blue Land
+  334  VSNPPDBO    -100  VIIRS SNPP Deep Blue Ocean
+  335  VSNPPDBD    -100  VIIRS SNPP Deep Blue Deep
+  336  VSNPPDTL    -100  VIIRS SNPP Dark Target Land
+  337  VSNPPDTO    -100  VIIRS SNPP DARK Target Ocean
+  338      -100  VIIRS NOAA20 Deep Blue LAND
+  339      -100  VIIRS NOAA20 Deep Blue OCEAN
+  340  VN20DBD    -100  VIIRS NOAA20 Deep Blue DEEP
+  341  VN20DTL    -100  VIIRS NOAA20 Dark Target LAND
+  342  VN20DTO    -100  VIIRS NOAA20 Dark Target OCEAN
+  343      -100  Lunar Aeronet  
 
 ::      # End of DataSourceTable
 
@@ -206,6 +217,37 @@ ObsErr*AVHRR::   # kx = 324 (like MYDO)
   q_UprAir.u  0.22   0.21   0.20   0.19 
 ::
 
+ObsErr*VSNPPDBO::   # kx = 334
+  q_UprAir.u  0.19   0.19   0.18   0.18
+::
+
+ObsErr*VSNPPDBL::   # kx = 333
+  q_UprAir.u  0.19   0.19   0.18   0.18
+::
+
+ObsErr*VSNPPDBD::   # kx = 335
+  q_UprAir.u  0.19   0.19   0.18   0.18
+::
+
+ObsErr*VSNPPDTO::   # kx = 336
+  q_UprAir.u  0.19   0.19   0.18   0.18
+::
+
+ObsErr*VSNPPDTL::   # kx = 337
+  q_UprAir.u  0.19   0.19   0.18   0.18
+::
+
+ObsErr*VN20DBD::   # kx = 340
+  q_UprAir.u  0.19   0.19   0.18   0.18
+::
+
+ObsErr*VN20DTO::   # kx = 342
+  q_UprAir.u  0.19   0.19   0.18   0.18
+::
+
+ObsErr*VN20DTL::   # kx = 341
+  q_UprAir.u  0.19   0.19   0.18   0.18
+::
 #...............................................................................
 
 #              --------------------------------------------------


### PR DESCRIPTION
-Update of ana.rc.tmpl with NOAA 20 filename
-Update psas.rc with VIIRS names but also obs errors
•Buddy Check: m_sqc.F90 updated with openMP that works. Original code crashes with segmentation fault when turning on openMP. New code is 0 diff to the old code if you turn off openMP and 0 diff between openMP on/off
•GAAS_App/CMakeLists.txt: target_link_libraries(${this} PRIVATE OpenMP::OpenMP_Fortran)
•Needs setenv OMP_NUM_THREADS 20 (I tested with 20 and works quite fast)

•When running offline this appears: in ana_aod.csh:
                  # Running environment
                  # -------------------
                     set NCPUS = $cpu
                    limit  stack           unlimited
                    setenv ARCH `uname -s`
                    setenv PSAS_NUM_MPI    $NCPUS # for PSAS
                    setenv MPIRUN          "mpirun -np $PSAS_NUM_MPI"
                    setenv OMP_NUM_THREADS 20 # for SQC

Online: is it in ana_aod.j.tmpl? That setenv OMP_NUM_THREADS  should be added. Should it come from higher up.
 