### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,16 @@
 /.mepo/
 parallel_build.o*
 log.*
+
+CMakeUserPresets.json
+
+# Ignore possible symlinked directories
+build-*
+install-*
+
+*.swp
+*.swo
+.DS_Store
+*#
+.#*
+**/CVS/


### PR DESCRIPTION
This PR updates the `.gitignore` in GEOSadas to match that of GEOSgcm. The additions are:

* Ignore anything named `build-*` and `install-*`. NOTE: This is primarily for, well, me as for disk reasons, my builds and installs are on a different disk volume. So I symlink in my builds/installs. This way, I don't accidentally commit them 🙂 
* Ignore any `CMakeUserPresets.json`. This is [advice from CMake](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#id3): "For example, if a project is using Git, `CMakePresets.json` may be tracked, and `CMakeUserPresets.json` should be added to the `.gitignore`."
* Finally, a bunch of dotfiles and other things often used for tempfiles, etc. (And our old friend `CVS/`)