### PR TITLE
added obserror for VN20DBL and VN20DBO to avoid an I90/lablin in the log

### DIFF
--- a/src/Applications/GAAS_App/psas.rc
+++ b/src/Applications/GAAS_App/psas.rc
@@ -242,6 +242,15 @@ ObsErr*VN20DBD::   # kx = 340
   q_UprAir.u  0.22   0.21   0.20   0.19
 ::
 
+
+ObsErr*VN20DBL::   # kx = 338
+  q_UprAir.u  0.22   0.21   0.20   0.19
+::
+
+ObsErr*VN20DBO::   # kx = 339
+  q_UprAir.u  0.22   0.21   0.20   0.19
+::
+
 ObsErr*VN21DTL::   # kx = 344
   q_UprAir.u  0.19   0.19   0.18   0.18
 ::


### PR DESCRIPTION
Updated PSAS.rc to avoid seeing an I90/lablin in the log for VN20DBL amd VN20DBO.

 **No impact** on the VIIRS DA since those VIIRS data are not currently used. 