### PR TITLE
WIP: Fixes for lowres testsuites

### DIFF
--- a/src/Applications/GEOSdas_App/testsuites/C48f.input
+++ b/src/Applications/GEOSdas_App/testsuites/C48f.input
@@ -36,6 +36,9 @@ EXPDSC? [C48f__GEOSadas-5_30_0__agrid_C48__ogrid_f34]
 Land Boundary Conditions? [Icarus_Updated]
 > 
 
+Catchment Model choice? [1]
+> 
+
 FVHOME? [/discover/nobackup/jstassi/C48f]
 > 
 
@@ -43,7 +46,7 @@ The directory /discover/nobackup/jstassi/C48f does not exist. Create it now? [y]
 > 
 
 Processing nodes (1:Haswell, 2:Skylake, 3:Cascase, 4:Milan)? [2]
-> 
+> 4
 
 Which case of variational analysis? [1]
 > 

--- a/src/Applications/GEOSdas_App/testsuites/C90C.input
+++ b/src/Applications/GEOSdas_App/testsuites/C90C.input
@@ -35,6 +35,9 @@ EXPDSC? [C90C__GEOSadas-5_30_0__agrid_C90__ogrid_CS]
 Land Boundary Conditions? [Icarus_Updated]
 > Icarus-NLv3
 
+Catchment Model choice? [1]
+> 
+
 FVHOME? [/discover/nobackup/jstassi/C90C]
 > 
 
@@ -42,7 +45,8 @@ The directory /discover/nobackup/jstassi/C90C does not exist. Create it now? [y]
 > 
 
 Processing nodes (1:Haswell, 2:Skylake, 3:Cascase, 4:Milan)? [2]
-> 
+> 4
+
 Which case of variational analysis? [1]
 > 
 


### PR DESCRIPTION
As found by @weiyuan-jiang, `runjob.pl` (aka `fvsetup`) is unhappy with the `C90C.input` file. The reason was a missing question/answer pair in the file for catchment.

I found something similar in the `C48f.input` file as well.

NOTE: At the moment, @weiyuan-jiang cannot complete an `fvsetup` even on the fix. Current issues are:

1. The `C90C.input` restarts are missing `gwd_internal_rst`