### PR TITLE
Revise capability to convert ncdiag to ioda on the fly

### DIFF
--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -3702,12 +3702,16 @@ sub set_geosjedi {
   if ( ! $ENV{GEOSJEDI} ) { return 0 };
 
   $nogsi = " ";
-  if ( $skipgsi ) { $nogsi = "-nogsi" };
-
-  if( $ENV{OFFLINE_IODA_DIR} ) {
-     $iodadir = $ENV{OFFLINE_IODA_DIR};
+  if ( $skipgsi ) { 
+     $nogsi = "-nogsi";
+     if( $ENV{OFFLINE_IODA_DIR} ) {
+        $iodadir = $ENV{OFFLINE_IODA_DIR};
+     } else {
+        $iodadir = "/discover/nobackup/projects/gmao/dadev/rtodling/archive/541/Milan/x0050/ioda/";
+     }
   } else {
-     $iodadir = "/discover/nobackup/projects/gmao/dadev/rtodling/archive/541/Milan/x0050/ioda/";
+     $iodadir = "/dev/null"; # this expects ncdiag files to be created by GSI
+                             # so that JEDIana can convert files to IODA on the fly
   }
   $xtra4jedi = "";
   if ( $jedi_ensrpy ) {

--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -3707,7 +3707,8 @@ sub set_geosjedi {
      if( $ENV{OFFLINE_IODA_DIR} ) {
         $iodadir = $ENV{OFFLINE_IODA_DIR};
      } else {
-        $iodadir = "/discover/nobackup/projects/gmao/dadev/rtodling/archive/541/Milan/x0050/ioda/";
+#       $iodadir = "/discover/nobackup/projects/gmao/dadev/rtodling/archive/541/Milan/x0050/ioda/";
+        $iodadir = "/discover/nobackup/projects/gmao/dadev/rtodling/archive/544/x0054/ioda/";
      }
   } else {
      $iodadir = "/dev/null"; # this expects ncdiag files to be created by GSI

--- a/src/Applications/GEOSdas_App/jedi/etc/CMakeLists.txt
+++ b/src/Applications/GEOSdas_App/jedi/etc/CMakeLists.txt
@@ -2,6 +2,7 @@ set (ALLETC
    JEDIanaConfig.csh
    SWELLConfig.csh
    diffstates_geos.yaml
+   diag2ioda.yaml
    geos_3dvar.yaml
    geos_3dfgat.yaml
    geos_hyb3dcenvar.yaml

--- a/src/Applications/GEOSdas_App/jedi/etc/JEDIadanaConfig.csh
+++ b/src/Applications/GEOSdas_App/jedi/etc/JEDIadanaConfig.csh
@@ -1,0 +1,51 @@
+# SLURM specials
+setenv GEOSJEDI_QOS @GEOSJEDI_QOS
+setenv GEOSJEDI_PARTITION  @GEOSJEDI_PARTITION
+
+# Top options
+setenv JEDI_SET    1           # bring bkg/obs/ens
+setenv JEDI_RUN    1           # run JEDI var executable
+setenv JEDI_HYBRID @JEDI_HYBRID           # control opts for hyb JEDI
+setenv JEDI_MKIAU  1           # calculates IAU output
+setenv JEDI_POST   0           # process results (move files, etc)
+setenv JEDI_IAU_OVERWRITE  @JEDI_IAU_OVERWRITE   # overwrite GSI-IAU with JEDI-IAU (when cycling)
+setenv JEDI_RUN_ADANA_TEST 0   # run adjoint JEDI-Var
+setenv JEDI_VAROFFSET 10800    # background time offset
+setenv JEDI_FEEDBACK_VARBC @JEDI_FEEDBACK_VARBC   # controls whether or not to feedback biases
+
+setenv JEDI_SWELLUSE 0  # bypass use of SWELL for now
+setenv SWELL_INSTALL @SWELL_INSTALL
+setenv OFFLINE_IODA_DIR @OFFLIODADIR # /discover/nobackup/projects/gmao/dadev/rtodling/archive/530/x0049/R2D2DataStore/Local/v2/
+
+# Details ...
+setenv MAPLFIX      0
+setenv JEDI_OBS_OPT 1              # 1= point to xexp-like set (data in tar-balls; data from existing exp)
+                                   # 2= point to existing set of ncdiag-ioda-converted set (swell/.../DATE/geos_atmosphere)
+                                   # 3= generate on the fly based on GSI (nc4) diags (TBD)
+
+setenv JEDI_ROOT @JEDI_ROOT
+
+# Specific to run procedure
+setenv JEDI_RUN_ANA      1
+setenv JEDI_RUN_CNVANA   0   # convert cc ana and/or inc output to ll
+setenv JEDI_RUN_GETINC   @JEDI_RUN_GETINC   # calc cubed inc from diff of cubed ana and bkg
+setenv JEDI_RUN_UPDRST   0   # not desirable
+
+setenv JEDI_DIF_NCPUS    @JEDI_DIF_NCPUS
+setenv JEDI_NCPUS        @JEDI_VAR_NCPUS
+
+setenv JEDI_ADDINC_MPIRUN "mpirun -np 12"
+setenv JEDI_CNVANA_MPIRUN "mpirun -np 12"
+setenv JEDI_CNVENS_MPIRUN "mpirun -np 12"
+setenv JEDI_CNVINC_MPIRUN "mpirun -np 12"
+setenv JEDI_GETINC_MPIRUN "mpirun -np $JEDI_DIF_NCPUS"
+setenv JEDI_FV3VAR_MPIRUN "mpirun -perhost @JEDI_VAR_PERHOST -np $JEDI_NCPUS"
+
+setenv JEDI_MKIAU_MPIRUN "mpirun "
+
+setenv JEDI_STATIC_FILES @JEDI_STATIC_FILES
+setenv JEDI_CRTM_COEFFS  $FVHOME/fvInput/gsi/etc/JEDI-CRTM-2.4.1j1-GMAO/Little_Endian/
+setenv JEDI_INPUT @JEDI_INPUT
+
+# post
+setenv JEDI_CONCAT_IODA  0

--- a/src/Applications/GEOSdas_App/jedi/etc/JEDIanaConfig.csh
+++ b/src/Applications/GEOSdas_App/jedi/etc/JEDIanaConfig.csh
@@ -14,6 +14,8 @@ setenv JEDI_VAROFFSET 10800    # background time offset
 setenv JEDI_FEEDBACK_VARBC @JEDI_FEEDBACK_VARBC   # controls whether or not to feedback biases
 
 setenv JEDI_SWELLUSE 0  # bypass use of SWELL for now
+setenv SWELL_INSTALL @SWELL_INSTALL
+setenv SWELL_CONVNCDIAG_SUITE $FVWORK/${EXPID}-convert_ncdiags
 setenv OFFLINE_IODA_DIR @OFFLIODADIR # /discover/nobackup/projects/gmao/dadev/rtodling/archive/530/x0049/R2D2DataStore/Local/v2/
 
 # Details ...
@@ -22,7 +24,7 @@ setenv JEDI_OBS_OPT @JEDI_OBS_OPT  # 1= point to xexp-like set (data in tar-ball
                                    # 2= point to existing set of ncdiag-ioda-converted set (swell/.../DATE/geos_atmosphere)
                                    # 3= generate on the fly based on GSI (nc4) diags (TBD)
 
-setenv JEDI_GSI2IODA 0
+setenv JEDI_GSI2IODA @JEDI_GSI2IODA
 setenv JEDI_OBS_DIR $FVWORK/IODA
 
 setenv JEDI_ROOT @JEDI_ROOT

--- a/src/Applications/GEOSdas_App/jedi/etc/JEDIanaConfig.csh
+++ b/src/Applications/GEOSdas_App/jedi/etc/JEDIanaConfig.csh
@@ -15,7 +15,6 @@ setenv JEDI_FEEDBACK_VARBC @JEDI_FEEDBACK_VARBC   # controls whether or not to f
 
 setenv JEDI_SWELLUSE 0  # bypass use of SWELL for now
 setenv SWELL_INSTALL @SWELL_INSTALL
-setenv SWELL_CONVNCDIAG_SUITE $FVWORK/${EXPID}-convert_ncdiags
 setenv OFFLINE_IODA_DIR @OFFLIODADIR # /discover/nobackup/projects/gmao/dadev/rtodling/archive/530/x0049/R2D2DataStore/Local/v2/
 
 # Details ...
@@ -23,9 +22,6 @@ setenv MAPLFIX      0
 setenv JEDI_OBS_OPT @JEDI_OBS_OPT  # 1= point to xexp-like set (data in tar-balls; data from existing exp)
                                    # 2= point to existing set of ncdiag-ioda-converted set (swell/.../DATE/geos_atmosphere)
                                    # 3= generate on the fly based on GSI (nc4) diags (TBD)
-
-setenv JEDI_GSI2IODA @JEDI_GSI2IODA
-setenv JEDI_OBS_DIR $FVWORK/IODA
 
 setenv JEDI_ROOT @JEDI_ROOT
 

--- a/src/Applications/GEOSdas_App/jedi/etc/SWELLConfig.csh
+++ b/src/Applications/GEOSdas_App/jedi/etc/SWELLConfig.csh
@@ -1,11 +1,2 @@
-
-#source /discover/nobackup/projects/gmao/advda/swell/jedi_modules/spackstack_1.9_intel_bundle
-
-module use -a /discover/nobackup/projects/gmao/advda/swell/dev/modulefiles/core
-module load py_lmod_installer
-
-module use /discover/nobackup/projects/gmao/advda/rtodling/JEDI1/SWELL/SPACK19/opt/modulefiles/core
-module load swell/Mar18
-
-#module unload py-pycodestyle/2.8.0
-
+module use @SWELL_INSTALL/modulefiles/core
+module load swell/swell

--- a/src/Applications/GEOSdas_App/jedi/etc/diag2ioda.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/diag2ioda.yaml
@@ -1,0 +1,133 @@
+# What is the experiment id?
+experiment_id: ${EXPID}-convert_ncdiags
+
+# What is the experiment root (the directory where the experiment will be stored)?
+experiment_root: $JEDIWORK
+
+# What is the time of the first cycle (middle of the window)?
+start_cycle_point: '$JEDI_ISO_DATE_ANA'
+
+# What is the time of the final cycle (middle of the window)?
+final_cycle_point: '$JEDI_ISO_DATE_ANA'
+
+# List of models in this experiment
+model_components:
+- geos_atmosphere
+
+# Set the Cylc runahead limit: the maximum number of cycles that may be active ahead of the current cycle (e.g. P1: up to 1 cycle ahead, P3: up to 3 cycles ahead, default P4).
+runahead_limit: P4
+
+# What experiment_id should r2d2 reference for experiment?
+r2d2_experiment_id: swell-convert_ncdiags
+
+# Skip registering and storing results of this experiment in R2D2?
+skip_r2d2: false
+
+# Do you want to use an existing JEDI build or create a new build?
+jedi_build_method: use_existing
+
+# What is the path to the existing JEDI build directory?
+existing_jedi_build_directory: $JEDI_ROOT
+
+# What is the path to the existing JEDI source code directory?
+existing_jedi_source_directory: $JEDI_ROOT/../
+
+# Configurations for the model components.
+models:
+
+  # Configuration for the geos_atmosphere model component.
+  geos_atmosphere:
+
+    # Enter the cycle times for this model.
+    cycle_times:
+    - T00
+    - T06
+    - T12
+    - T18
+
+    # What is the location where GSI bias correction files can be found?
+    path_to_gsi_bc_coefficients: $JEDIWORK/GSIBIAS/*bias*%Y%m%d_%Hz.txt
+
+    # What is the duration for the data assimilation window?
+    window_length: PT6H
+
+    # What is the path to where the GSI ncdiags are stored?
+    path_to_gsi_nc_diags: $JEDIWORK/GSIDIAGS
+
+    # Which observations do you want to include?
+    observations:
+    - abi_g18
+    - aircraft
+    - airs_aqua
+    - amsr2_gcom-w1
+    - amsua_aqua
+    - amsua_metop-b
+    - amsua_metop-c
+    - amsua_n15
+    - amsua_n18
+    - amsua_n19
+    - atms_n20
+    - atms_n21
+    - atms_npp
+    - avhrr3_metop-b
+    - avhrr3_metop-c
+    - avhrr3_n18
+    - avhrr3_n19
+    - cris-fsr_n20
+    - cris-fsr_n21
+    - cris-fsr_npp
+    - gmi_gpm
+    - gps
+    - iasi_metop-b
+    - iasi_metop-c
+    - mhs_metop-b
+    - mhs_metop-c
+    - mhs_n19
+    - mls55_aura
+    - omi_aura
+    - omieff_aura
+    - ompslpnc_n21
+    - ompslpnc_npp
+    - ompsnm_npp
+    - pibal
+    - satwind
+    - scatwind
+    - sfcship
+    - sfc
+    - sondes
+    - ssmis_f17
+
+    # When running the ncdiag to ioda converted do you want to produce GeoVaLs files?
+    produce_geovals: false
+
+    # Is it a single-observation test?
+    single_observations: false
+
+    # Provide a list of patterns that you wish to remove from the cycle directory.
+    clean_patterns:
+    - gsi_bcs/*.nc4
+    - gsi_bcs/*.txt
+    - gsi_bcs/*.yaml
+    - gsi_bcs
+    - gsi_ncdiags/*.nc4
+    - gsi_ncdiags/aircraft/*.nc4
+    - gsi_ncdiags/aircraft
+    - gsi_ncdiags
+
+    # How long before the middle of the analysis window did the background providing forecast begin?
+    background_time_offset: PT9H
+
+    # What is the path to the CRTM coefficient files?
+    crtm_coeff_dir: $JEDI_CRTM_COEFFS
+
+    # What is the path to the Swell formatted observing system records?
+    observing_system_records_path: None
+
+# Datetime this file was created (auto added)
+datetime_created: 20260331_163310Z
+
+# Computing platform to run the experiment
+platform: nccs_discover_sles15
+
+# Record of the suite being executed
+suite_to_run: convert_ncdiags

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_3dfgat.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_3dfgat.yaml
@@ -5,6 +5,7 @@ cost function:
   - air_temperature
   - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_3dvar.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_3dvar.yaml
@@ -22,6 +22,7 @@ cost function:
   - air_temperature
   - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_hyb3denvar.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_hyb3denvar.yaml
@@ -5,6 +5,7 @@ cost function:
   - air_temperature
   - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water
@@ -105,7 +106,7 @@ cost function:
 #     mole_fraction_of_carbon_dioxide_in_air: co2
   background error:
     covariance model: SABER
-    covariance type: gsi static covariance
+#   covariance type: gsi static covariance
 #   adjoint test: true
     saber central block:
       saber block name: gsi hybrid covariance

--- a/src/Applications/GEOSdas_App/jedi/etc/geos_hyb4denvar.yaml
+++ b/src/Applications/GEOSdas_App/jedi/etc/geos_hyb4denvar.yaml
@@ -5,6 +5,7 @@ cost function:
   - air_temperature
   - water_vapor_mixing_ratio_wrt_moist_air
   - air_pressure_at_surface
+  - air_pressure_levels
   - cloud_liquid_ice
   - cloud_liquid_water
   - rain_water

--- a/src/Applications/GEOSdas_App/jedi/etc/jedi_asens.j
+++ b/src/Applications/GEOSdas_App/jedi/etc/jedi_asens.j
@@ -1,0 +1,76 @@
+#!/bin/csh -fx
+#SBATCH --account=$GID
+@GEOSJEDI_QOS
+@GEOSJEDI_PARTITION
+#SBATCH --job-name=jasens
+#SBATCH --output=jasens.log.o%j.txt
+#SBATCH --ntasks=216
+#SBATCH --constraint=mil
+#SBATCH --time=2:00:00
+
+#######################################################
+#######################################################
+######                                           ######
+######   CAUTION: NOT READY YET                  ######
+######                                           ######
+#######################################################
+#######################################################
+
+setenv EXPID $EXPID
+setenv FVHOME $FVHOME
+setenv FVROOT `cat $FVHOME/.FVROOT`
+setenv JEDI_RUN_ADANA 1
+
+setenv JFSENSLOC /discover/nobackup/projects/gmao/dadev/rtodling/Debug/Convert/4JEDI
+
+setenv GID $GID
+setenv BATCH_SUBCMD sbatch
+
+if ( ! -d $FVHOME/run/jedi ) then
+   echo "No JEDI settings have been found within GEOS, abort"
+   exit 1
+endif
+
+set path = ( . $FVHOME/run/jedi $FVHOME/run $FVROOT/bin $path )
+source $FVROOT/bin/g5_modules
+
+cd $JFSENSLOC
+if ( $?this_nymd ) then
+   set fsenslst = `ls $EXPID.jfsens_twe.eta.????????_??z+????????_??z-${this_nymd}_00z.nc4`
+else
+   set fsenslst = `ls *jfsens*nc4`
+endif
+echo "Will work on the following forecast sensitivities:"
+echo $fsenslst
+echo " "
+
+cd -
+
+setenv FVWORK /discover/nobackup/projects/gmao/obsdev/rtodling/jediwork/tmpjasens.$$
+setenv HOLDRESULTS $FVWORK/Results
+mkdir -p $FVWORK
+mkdir -p $HOLDRESULTS
+cd $FVWORK
+
+foreach sensfn ( $fsenslst )
+
+  echo $sensfn
+  set ttag = `echo $sensfn | cut -d. -f4 | cut -d- -f2`
+  echo $ttag
+  set nymda = `echo $ttag | cut -c1-8`
+  set hha   = `echo $ttag | cut -c10-11`
+  set nhmsa = ${hha}0000
+
+  /bin/cp $JFSENSLOC/$sensfn jedi.fsens.eta.nc4
+
+  set bdatetime = ( `tick $nymda $nhmsa -10800` )
+
+  if ( -d $FVWORK/jana ) /bin/rm -r $FVWORK/jana
+
+  jedi_driver.csh $bdatetime[1] $bdatetime[2] $nymda $nhmsa |& tee -a $FVWORK/$EXPID.jedi_asens.log.${nymda}_${hha}z.txt
+
+  /bin/mv *.tar *.txt $HOLDRESULTS/
+
+end
+# /bin/rm $FVWORK
+cd -

--- a/src/Applications/GEOSdas_App/jedi/etc/ut_jedi.j
+++ b/src/Applications/GEOSdas_App/jedi/etc/ut_jedi.j
@@ -9,6 +9,7 @@ setenv FVROOT `cat $FVHOME/.FVROOT`
 setenv FVWORK `cat $FVHOME/.FVWORK`
 setenv JEDIDIR $FVHOME/run/jedi
 setenv VAROFFSET 180
+setenv TIMEINC 360
 
 source $FVROOT/bin/g5_modules
 source $FVHOME/run/jedi/JEDIanaConfig.csh

--- a/src/Applications/GEOSdas_App/jedi/jedi_driver.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_driver.csh
@@ -28,6 +28,7 @@ set   mma = `echo nymda | cut -c5-6`
 set   dda = `echo nymda | cut -c7-8`
 set   hhb = `echo $nhmsb | cut -c1-2`
 set   hha = `echo $nhmsa | cut -c1-2`
+set yyyymmddhh = ${nymda}${hha}
 
 setenv NYMDA $nymda
 setenv   HHA $hha
@@ -60,8 +61,13 @@ else
   source  $FVHOME/run/jedi/JEDIanaConfig.csh
 endif
 
+if ( -e $FVWORK/.DONE_${MYNAME}.$yyyymmddhh ) then
+   echo "${MYNAME}: all done"
+   exit(0)
+endif
+
 setenv JEDIWORK $FVWORK/jedi.$nymda.$nhmsa
-if ( ! -d $JEDIWORK ) mkdir -p $JEDIWORK/swell
+if ( ! -d $JEDIWORK ) mkdir -p $JEDIWORK/jedi.$nymda.$nhmsa
 
 # Setup SWELL & IODA Files
 # ========================
@@ -72,23 +78,23 @@ if ( $JEDI_SWELLUSE && $JEDI_OBS_OPT == 3 ) then
      exit (1)
   endif
 
-  # Convert GSI-nc4-diag files to IODA
-  # ----------------------------------
-  if ( $JEDI_GSI2IODA ) then
-    jedi_gsi2ioda.csh $nymda $nhmsa $FVWORK $FVWORK $JEDIWORK
-    if ( $status ) then
-      echo "Trouble converting GSI output to IODA, aborting ..."
-      exit 1
-    endif
-  endif
-
 else
 
 # If here, IODA files must be available 
 # -------------------------------------
   if ( $OFFLINE_IODA_DIR == "/dev/null" ) then
+
+     # Convert GSI-nc4-diag files to IODA
+     # ----------------------------------
+     if ( $JEDI_GSI2IODA ) then
+       jedi_gsi2ioda.csh $nymda $nhmsa $FVWORK $FVWORK $JEDIWORK
+       if ( $status ) then
+         echo "Trouble converting GSI output to IODA, aborting ..."
+         exit 1
+       endif
+     endif
+
   else
-#    set IODADIR = $OFFLINE_IODA_DIR/Y$yyyya/M$mma/D$dda/H$hha/
      set IODADIR = $OFFLINE_IODA_DIR/${nymda}T${hha}0000Z/geos_atmosphere
      if ( ! -d $FVWORK/ioda.${nymda}_${hha}0000 ) mkdir $FVWORK/ioda.${nymda}_${hha}0000
      cd $FVWORK/ioda.${nymda}_${hha}0000
@@ -161,7 +167,7 @@ if ( $?SKIPGSI ) then
      echo " ${MYNAME}: WARNING, JEDI-related IAU will be used in model integration. "
    endif
 endif
-if ( $JEDI_IAU_OVERWRITE ) then
+if ( $JEDI_MKIAU && $JEDI_IAU_OVERWRITE ) then
   zeit_ci.x jedi_up4geos
   jedi_upd4geos.csh $nymdb $nhmsb |& tee -a $FVWORK/$EXPID.jedi_upd.log.${nymdb}_${hhb}z.txt
   if ( $status ) then
@@ -171,4 +177,8 @@ if ( $JEDI_IAU_OVERWRITE ) then
   zeit_co.x jedi_up4geos
 endif
 
+# If here, likely successful
+# --------------------------
+touch $FVWORK/.DONE_${MYNAME}.$yyyymmddhh
+echo " ${MYNAME}: Complete "
 exit(0)

--- a/src/Applications/GEOSdas_App/jedi/jedi_driver.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_driver.csh
@@ -51,7 +51,7 @@ if ( !($?JEDI_POST) )  setenv JEDI_POST  0
 if ( !($?JEDI_IAU_OVERWRITE) )  setenv JEDI_IAU_OVERWRITE  0
 if ( !($?JEDI_RUN_ADANA_TEST) ) setenv JEDI_RUN_ADANA_TEST 0
 if ( !($?JEDI_RUN_ADANA) ) setenv JEDI_RUN_ADANA 0
-if ( !($?JEDI_GSI2IODA) ) setenv JEDI_GSI2IODA 0
+if ( !($?JEDI_OBS_OPT) ) setenv JEDI_OBS_OPT 0
 if ( !($?JEDI_SWELLUSE) ) setenv JEDI_SWELLUSE 1
 if ( !($?OFFLINE_IODA_DIR) ) setenv OFFLINE_IODA_DIR /dev/null
 
@@ -71,7 +71,7 @@ if ( ! -d $JEDIWORK ) mkdir -p $JEDIWORK/jedi.$nymda.$nhmsa
 
 # Setup SWELL & IODA Files
 # ========================
-if ( $JEDI_SWELLUSE && $JEDI_OBS_OPT == 3 ) then
+if ( $JEDI_SWELLUSE ) then
   jedi_swellset.csh $nymda $nhmsa $JEDIDIR $JEDIWORK
   if ($status) then
      echo "${MYNAME}: failed, aborting ..."
@@ -82,11 +82,11 @@ else
 
 # If here, IODA files must be available 
 # -------------------------------------
-  if ( $OFFLINE_IODA_DIR == "/dev/null" ) then
+  if ( $OFFLINE_IODA_DIR == "/dev/null" || $OFFLINE_IODA_DIR == "/dev/null/" ) then
 
      # Convert GSI-nc4-diag files to IODA
      # ----------------------------------
-     if ( $JEDI_GSI2IODA ) then
+     if ( $JEDI_OBS_OPT == 3 ) then
        jedi_gsi2ioda.csh $nymda $nhmsa $FVWORK $FVWORK $JEDIWORK
        if ( $status ) then
          echo "Trouble converting GSI output to IODA, aborting ..."

--- a/src/Applications/GEOSdas_App/jedi/jedi_gsi2ioda.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_gsi2ioda.csh
@@ -62,7 +62,7 @@ endif
 
 if ( !($?JEDI_ROOT)  )  setenv FAILED   1
 if ( !($?JEDI_CRTM_COEFFS) )  setenv FAILED   1
-if ( !($?JEDI_GSI2IODA)  )  setenv FAILED   1
+if ( !($?JEDI_OBS_OPT)  )  setenv FAILED   1
 
 if ( $SYSFAILED ) then
   env
@@ -75,7 +75,7 @@ if ( $FAILED ) then
   exit (1)
 endif
 
-if ( ! $JEDI_GSI2IODA ) then
+if ( $JEDI_OBS_OPT != 3 ) then
    echo "${MYNAME}: skipping GSI2IODA ..."
    exit(0)
 endif 
@@ -102,7 +102,7 @@ set pdda      = `echo $pnymda | cut -c7-8`
 set phha      = `echo $pnhmsa | cut -c1-2`
 
 # Convert GSI-nc4-diag files to IODA
-if ( $JEDI_GSI2IODA ) then
+#if ( $JEDI_OBS_OPT == 3 ) then
   cd $JEDIWORK
 
   # link diag files for conversion
@@ -139,7 +139,7 @@ if ( $JEDI_GSI2IODA ) then
      if ( -d ~/cylc-run/${EXPID}-convert_ncdiags-suite ) then
         /bin/rm -r ~/cylc-run/${EXPID}-convert_ncdiags-suite
      endif
-     $DRYRUN swell create convert_ncdiags --override diag2ioda.yaml
+     $DRYRUN swell create convert_ncdiags --skip-r2d2 --override diag2ioda.yaml
   else
      echo "Trouble finding diag2ioda.yaml, aborting ..."
      exit 1
@@ -162,7 +162,7 @@ if ( $JEDI_GSI2IODA ) then
         exit 1
      endif
    endif
-endif
+#endif
 
 touch $FVWORK/.DONE_${MYNAME}.$yyyymmddhh
 echo " ${MYNAME}: Complete "

--- a/src/Applications/GEOSdas_App/jedi/jedi_gsi2ioda.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_gsi2ioda.csh
@@ -1,6 +1,7 @@
-#!/bin/csh
+#!/bin/csh -x
 
 setenv MYNAME jedi_gsi2ioda.csh
+setenv DRYRUN #echo
 
 if ( ! $?FVHOME ) then
   env
@@ -10,6 +11,7 @@ endif
 
 if ( ! -d $FVHOME/run/jedi ) then 
    echo " ${MYNAME}: Nothing to do."
+   exit (1)
 else
    setenv JEDIDIR $FVHOME/run/jedi
 endif
@@ -27,11 +29,16 @@ set jediwk = $5
 set hha = `echo $nhmsa | cut -c1-2`
 set yyyymmddhh = ${nymda}${hha}
 
+setenv SYSFAILED 0
+if ( !($?LMOD_CMD)  )  setenv SYSFAILED  1
+if ( !($?LMOD_SETTARG_CMD)  )  setenv SYSFAILED  1
+
 setenv FAILED 0
 if ( !($?EXPID)   )  setenv FAILED   1
 if ( !($?FVHOME)  )  setenv FAILED   1
 if ( !($?FVWORK)  )  setenv FAILED   1
-if ( !($?JEDI_GSI2IODA)  )  setenv FAILED   1
+if ( !($?SWELL_INSTALL)  )  setenv FAILED   1
+if ( !($?TIMEINC)  )  setenv FAILED   1
 
 if ( $FAILED ) then
   env
@@ -54,7 +61,14 @@ else
 endif
 
 if ( !($?JEDI_ROOT)  )  setenv FAILED   1
+if ( !($?JEDI_CRTM_COEFFS) )  setenv FAILED   1
+if ( !($?JEDI_GSI2IODA)  )  setenv FAILED   1
 
+if ( $SYSFAILED ) then
+  env
+  echo " ${MYNAME}: not all SYSTEM required env vars defined"
+  exit (1)
+endif
 if ( $FAILED ) then
   env
   echo " ${MYNAME}: not all required env vars defined"
@@ -66,10 +80,26 @@ if ( ! $JEDI_GSI2IODA ) then
    exit(0)
 endif 
 
-# This needs care: TBD wired for now
-source $JEDI_ROOT/modules
-module unload py-pycodestyle/2.8.0
+# set JEDI workdir
+setenv JEDIETC  $FVHOME/run/jedi/Config
 setenv JEDIWORK $jediwk
+
+# define ISO analysis date/time
+set yyyya    = `echo $nymda | cut -c1-4`
+set mma      = `echo $nymda | cut -c5-6`
+set dda      = `echo $nymda | cut -c7-8`
+set hha      = `echo $nhmsa | cut -c1-2`
+setenv JEDI_ISO_DATE_ANA  "${yyyya}-${mma}-${dda}T${hha}:00:00Z"
+
+# set time of previous analysis (for bias stuff)
+@ varlen = $TIMEINC * 60
+set panadate  = `tick $nymda $nhmsa -$varlen`
+set pnymda    = $panadate[1]
+set pnhmsa    = $panadate[2]
+set pyyyya    = `echo $pnymda | cut -c1-4`
+set pmma      = `echo $pnymda | cut -c5-6`
+set pdda      = `echo $pnymda | cut -c7-8`
+set phha      = `echo $pnhmsa | cut -c1-2`
 
 # Convert GSI-nc4-diag files to IODA
 if ( $JEDI_GSI2IODA ) then
@@ -79,36 +109,56 @@ if ( $JEDI_GSI2IODA ) then
   if ( -d GSIDIAGS ) /bin/rm -r GSIDIAGS
   mkdir GSIDIAGS
   cd GSIDIAGS
+  setenv GSIDIAGS_DIR `pwd`
   ln -sf $inpdir/$EXPID.diag_*_ges.*nc4 .
   cd -
   if ( -d GSIBIAS ) /bin/rm -r GSIBIAS
   mkdir GSIBIAS
   cd GSIBIAS
-# foreach ftype ( ana.satbiaspc ana.satbias ) # following needs attention (not right date/time)
-#    ln -sf $inpdir/$EXPID.$ftype.${nymda}_${hha}z.txt .
-  foreach ftype ( ana_satbias_rst ana_satbiaspc_rst ) # following needs attention (not right date/time)
-     /bin/cp $FVHOME/recycle/*${ftype}*txt .   # TBD
+  foreach ftype ( acftbias_rst ana_satbias_rst ana_satbiaspc_rst )
+     /bin/cp $FVHOME/recycle/*${ftype}*txt . 
+     # fix date/time - swell wants biases at syn-time ...
+     set fn = (`ls *$ftype*.txt`)
+     set pfx = `echo $fn[1] | cut -d. -f1-2`
+     set nfn = $pfx.${pnymda}_${phha}z.txt
+     if ( ! -e $nfn ) then
+        ln -s $fn $nfn 
+     endif
   end
-# foreach fname ( `ls *.txt` ) # following needs attention (not right date/time)
-#    set pfx = `echo $fname | cut -d. -f1-2` 
-#    /bin/mv $fname $pfx.${nymda}_${hha}z.txt
-# end
   cd - 
 
-  cd $JEDIWORK/swell
-  swell-geosadas-run_tasks.sh
+  # get positioned
+  cd $JEDIWORK
+
+  # prepare yaml for converting ncdiag to ioda
+  vED -env $JEDIETC/diag2ioda.yaml -o diag2ioda.yaml
+
+  # create convert suite
+  if ( -e diag2ioda.yaml ) then
+     source $JEDIDIR/SWELLConfig.csh
+     if ( -d ~/cylc-run/${EXPID}-convert_ncdiags-suite ) then
+        /bin/rm -r ~/cylc-run/${EXPID}-convert_ncdiags-suite
+     endif
+     $DRYRUN swell create convert_ncdiags --override diag2ioda.yaml
+  else
+     echo "Trouble finding diag2ioda.yaml, aborting ..."
+     exit 1
+  endif
+
+  # launch convert suite
+  swell launch $JEDIWORK/${EXPID}-convert_ncdiags/${EXPID}-convert_ncdiags-suite -b
   if ( $status ) then
      echo "Trouble converting GSI output to IODA, aborting ..."
      exit 1
   else
-     if ( -d $JEDIWORK/swell/swell-geosadas/run/${nymda}T${hha}0000Z/geos_atmosphere ) then
-        mkdir   $outdir/ioda.${nymda}_${hha}0000
-        /bin/mv $JEDIWORK/swell/swell-geosadas/run/${nymda}T${hha}0000Z/geos_atmosphere/*.nc4 \
+     if ( -d $JEDIWORK/${EXPID}-convert_ncdiags/run/${nymda}T${hha}0000Z/geos_atmosphere ) then
+        if (! -d $outdir/ioda.${nymda}_${hha}0000 ) mkdir -p $outdir/ioda.${nymda}_${hha}0000
+        /bin/mv $JEDIWORK/${EXPID}-convert_ncdiags/run/${nymda}T${hha}0000Z/geos_atmosphere/*.nc4 \
                 $outdir/ioda.${nymda}_${hha}0000
-        /bin/mv $JEDIWORK/swell/swell-geosadas/run/${nymda}T${hha}0000Z/geos_atmosphere/*.txt \
+        /bin/mv $JEDIWORK/${EXPID}-convert_ncdiags/run/${nymda}T${hha}0000Z/geos_atmosphere/*.txt \
                 $outdir/ioda.${nymda}_${hha}0000
      else
-        echo "$JEDIWORK/swell/swell-geosadas/run/${nymda}T${hha}0000Z/geos_atmosphere directory not found, aborting ..."
+        echo "$JEDIWORK/${EXPID}-convert_ncdiags/run/${nymda}T${hha}0000Z/geos_atmosphere directory not found, aborting ..."
         exit 1
      endif
    endif

--- a/src/Applications/GEOSdas_App/jedi/jedi_set.csh
+++ b/src/Applications/GEOSdas_App/jedi/jedi_set.csh
@@ -38,7 +38,6 @@ if ( !($?FVHOME)        )  setenv FAILED   1
 if ( !($?FVWORK)        )  setenv FAILED   1
 if ( !($?GID)           )  setenv FAILED   1
 if ( !($?JEDI_OBS_OPT)  )  setenv FAILED   1
-if ( !($?JEDI_OBS_DIR)  )  setenv FAILED   1
 if ( !($?JEDI_HYBRID)   )  setenv FAILED   1
 if ( !($?JEDI_FEEDBACK_VARBC) )  setenv FAILED   1
 if ( !($?OFFLINE_IODA_DIR) ) setenv FAILED   1
@@ -188,8 +187,8 @@ if ( $JEDI_RUN_ADANA || $JEDI_OBS_OPT == 1 ) then
   endif
 endif # adjoint analysis
 
-# Link IODA observation files
-# ---------------------------
+# Link IODA files from available from offline generation
+# ------------------------------------------------------
 if ( $JEDI_OBS_OPT == 2 ) then
    pwd
    ls
@@ -201,18 +200,23 @@ if ( $JEDI_OBS_OPT == 2 ) then
       exit 1
    endif
    cd -
-   echo " ${MYNAME}: linked IODA files successfully"
+   echo " ${MYNAME}: successfully linked offline available IODA files"
 endif
 
-# Link IODA observation files
-# ---------------------------
+# Link IODA observation files that have been generated on the fly
+# ---------------------------------------------------------------
 if ( $JEDI_OBS_OPT == 3 ) then
    pwd
    ls
    cd obs
-   ln -sf $FVWORK/ioda.${nymda}_${hha}0000/* .
+   if ( "$OFFLINE_IODA_DIR" == "/dev/null/" || "$OFFLINE_IODA_DIR" == "/dev/null" ) then
+      ln -sf $FVWORK/ioda.${nymda}_${hha}0000/* .
+   else
+      echo " ${MYNAME}: inconsistent settings, cannot link IODA files, aborting ..."
+      exit 1
+   endif
    cd -
-   echo " ${MYNAME}: linked IODA files successfully"
+   echo " ${MYNAME}: successfully linked IODA files generated on the fly"
 endif
 
 # If so, feedback VarBC (from previous cycle)

--- a/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
+++ b/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
@@ -117,12 +117,16 @@ sub init {
         $jedistatic = "/discover/nobackup/projects/gmao/advda/SwellStaticFiles";
    }
 
+   $gsi2ioda = 0;
    if ( $opt_iodadir ) {
-        $iodadir = $opt_iodadir;
-        $jedi_obs_opt = 2; # ioda files provided by user
-   } else {
+     if ( $opt_iodadir eq "/dev/null" ) {
         $iodadir = "/dev/null";
         $jedi_obs_opt = 3; # convert ncdiag-to-ioda on the fly
+        $gsi2ioda = 1;
+     } else {
+        $iodadir = $opt_iodadir;
+        $jedi_obs_opt = 2; # ioda files provided by user
+     }
    }
 
    if ( $opt_cvbc ) {
@@ -176,6 +180,9 @@ sub init {
    if ( $opt_nogsi ) {
       $nogsi = 1;
    }
+
+# Swell is wired for now
+  $swell_install = "/gpfsm/dnb10/projects/p61/rtodling/JEDI1/2026/SWELL/Apr";
 
 # other settings
    $jediinput = "$fvhome/fv3-jedi";
@@ -362,7 +369,8 @@ sub init {
 
 # build internal variables
 
-  @rc2conf   = qw ( diffstates_geos.yaml
+  @rc2conf   = qw ( diag2ioda.yaml
+                    diffstates_geos.yaml
                     mkiau.rc.tenv
                     obsop_name_map.yaml );
 
@@ -621,6 +629,7 @@ sub ed_conf_rc {
         if($rcd =~ /\@JEDI_HYBRID/)         {$rcd=~ s/\@JEDI_HYBRID/$jedihyb/g;  }
         if($rcd =~ /\@JEDI_INPUT/)          {$rcd=~ s/\@JEDI_INPUT/$jediinput/g;  }
         if($rcd =~ /\@JEDI_OBS_OPT/)        {$rcd=~ s/\@JEDI_OBS_OPT/$jedi_obs_opt/g;  }
+        if($rcd =~ /\@JEDI_GSI2IODA/)       {$rcd=~ s/\@JEDI_GSI2IODA/$gsi2ioda/g;  }
         if($rcd =~ /\@JEDI_IAU_OVERWRITE/)  {$rcd=~ s/\@JEDI_IAU_OVERWRITE/$nogsi/g;  }
         if($rcd =~ /\@JEDI_ROOT/)           {$rcd=~ s/\@JEDI_ROOT/$jediroot/g;  }
         if($rcd =~ /\@JEDI_RUN_GETINC/)     {$rcd=~ s/\@JEDI_RUN_GETINC/$jediinc/g;  }
@@ -629,6 +638,8 @@ sub ed_conf_rc {
         if($rcd =~ /\@JEDI_VAR_NCPUS/)      {$rcd=~ s/\@JEDI_VAR_NCPUS/$ncpus_var/g;  }
         if($rcd =~ /\@JEDI_VAR_PERHOST/)    {$rcd=~ s/\@JEDI_VAR_PERHOST/$perhost_var/g;  }
         if($rcd =~ /\@OFFLIODADIR/)         {$rcd=~ s/\@OFFLIODADIR/$iodadir/g;  }
+
+        if($rcd =~ /\@SWELL_INSTALL/)       {$rcd=~ s/\@SWELL_INSTALL/$swell_install/g;  }
 
         if($rcd =~ /\@NODENAME/)            {$rcd=~ s/\@NODENAME/$nodename/g; }
         print(LUN2 "$rcd\n");

--- a/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
+++ b/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
@@ -117,12 +117,11 @@ sub init {
         $jedistatic = "/discover/nobackup/projects/gmao/advda/SwellStaticFiles";
    }
 
-   $gsi2ioda = 0;
+   $jedi_obs_opt = 1; # point to tar-ball from x-like-exp
    if ( $opt_iodadir ) {
-     if ( $opt_iodadir eq "/dev/null" ) {
+     if ( $opt_iodadir eq "/dev/null" or $opt_iodadir eq "/dev/null/" ) {
         $iodadir = "/dev/null";
         $jedi_obs_opt = 3; # convert ncdiag-to-ioda on the fly
-        $gsi2ioda = 1;
      } else {
         $iodadir = $opt_iodadir;
         $jedi_obs_opt = 2; # ioda files provided by user
@@ -222,8 +221,8 @@ sub init {
        $gsixlayout = 21;
        $gsiylayout = 32;
        $perhost_var = 12;
-       $gsibec_lat = 361;
-       $gsibec_lon = 576;
+       $gsibec_lat = 721;
+       $gsibec_lon = 1152;
      } elsif ( $scheme eq "hyb4dcenvar" or $scheme eq "hyb4dcenvar_seq" ) {
        $i1res = $hres / 2 + 1; # resolution of inner loop (only used for BUMP opt for now)
        die "You are pushing the envelop, no settings for this yet, aborting ... \n";
@@ -238,11 +237,23 @@ sub init {
      }
   } elsif ( $cres == 361 ) {
      if ( $scheme eq "hyb4denvar" ) {
-       $varxlayout = 16;
-       $varylayout = 7;
-       $gsixlayout = 21;
-       $gsiylayout = 32;
-       $perhost_var = 12;
+       $gsibec_lat = 361;
+       $gsibec_lon = 576;
+       if ( $agcm_im == 720 ) {
+         $varxlayout = 16;
+         $varylayout = 7;
+         $gsixlayout = 21;
+         $gsiylayout = 32;
+         $perhost_var = 12;
+         $gsibec_lat = 721;
+         $gsibec_lon = 1152;
+       } else {
+         $varxlayout = 16;
+         $varylayout = 7;
+         $gsixlayout = 21;
+         $gsiylayout = 32;
+         $perhost_var = 12;
+       }
      } elsif ( $scheme eq "hyb4dcenvar_seq" ) {
        $varxlayout = 16;
        $varylayout = 7;
@@ -271,8 +282,6 @@ sub init {
        $gsiylayout = 6 * $gsixlayout;
        $perhost_var = 16;
      }
-     $gsibec_lat = 361;
-     $gsibec_lon = 576;
   } elsif ( $cres == 181 ) {
      if ( $scheme eq "hyb4denvar" ) {
        $varxlayout = 16;
@@ -384,6 +393,8 @@ sub init {
                     jedi_run_var.j
                     ut_jedi.j
                   );
+
+  @rc2adjedi  = qw ( JEDIadanaConfig.csh );
 
   @rc2jediobs = qw ( 0observations.yaml
                      aircraft_temperature.yaml
@@ -629,7 +640,6 @@ sub ed_conf_rc {
         if($rcd =~ /\@JEDI_HYBRID/)         {$rcd=~ s/\@JEDI_HYBRID/$jedihyb/g;  }
         if($rcd =~ /\@JEDI_INPUT/)          {$rcd=~ s/\@JEDI_INPUT/$jediinput/g;  }
         if($rcd =~ /\@JEDI_OBS_OPT/)        {$rcd=~ s/\@JEDI_OBS_OPT/$jedi_obs_opt/g;  }
-        if($rcd =~ /\@JEDI_GSI2IODA/)       {$rcd=~ s/\@JEDI_GSI2IODA/$gsi2ioda/g;  }
         if($rcd =~ /\@JEDI_IAU_OVERWRITE/)  {$rcd=~ s/\@JEDI_IAU_OVERWRITE/$nogsi/g;  }
         if($rcd =~ /\@JEDI_ROOT/)           {$rcd=~ s/\@JEDI_ROOT/$jediroot/g;  }
         if($rcd =~ /\@JEDI_RUN_GETINC/)     {$rcd=~ s/\@JEDI_RUN_GETINC/$jediinc/g;  }

--- a/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
+++ b/src/Applications/GEOSdas_App/jedi/setup_aanajedi.pl
@@ -108,7 +108,7 @@ sub init {
 
    $jedipartition = "#"; 
    if ( $ENV{"GEOSJEDI_PARTITION"} ) {
-      $jedipartition = "#SBATCH --qos=$GEOSJEDI_PARTITION";
+      $jedipartition = "#SBATCH --partition=$GEOSJEDI_PARTITION";
    }
 
    if ( $opt_jedistatic ) {

--- a/src/Applications/GEOSdas_App/testsuites/j3dfgat.input
+++ b/src/Applications/GEOSdas_App/testsuites/j3dfgat.input
@@ -81,7 +81,7 @@ AeroCom? [/discover/nobackup/projects/gmao/share/gmao_ops/fvInput_4dvar/AeroCom]
 > 
 
 FVICS? [/archive/u/jstassi/restarts/GEOSadas-5_24_0]
-> /discover/nobackup/projects/gmao/dadev/rtodling/archive/541/Milan/x0050/rs/Y2023/M10/x0050.rst.20231004_15z.tar
+> /discover/nobackup/projects/gmao/dadev/rtodling/archive/543/x0053RPY/rs/Y2025/M12/x0053RPY.rst.20251230_21z.tar
 
 Run model-adjoint-related applications (0=no,1=yes)? [0]
 > 
@@ -90,7 +90,7 @@ Run analysis-sensitivity applications (0=no,1=yes)? [0]
 > 
 
 Ending year-month-day? [20231206]
-> 20231010
+> 20260206
 
 Length of FORECAST run segments (in hours)? [123]
 > 
@@ -138,7 +138,7 @@ Which main class of ObsSys (1: NRT; 2: MERRA; 3: MERRA-2; 4: GEOS-IT; 5: R21C)? 
 > 
 
 OBSERVING SYSTEM CLASSES?
-> disc_airs_bufr,disc_amsua_bufr,gmao_amsr2_bufr,gmao_gmi_bufr,mls_nrt_nc,ncep_1bamua_bufr,ncep_acftpfl_bufr,ncep_atms_bufr,ncep_aura_omi_bufr,ncep_avcsam_bufr,ncep_avcspm_bufr,ncep_crisfsr_bufr,ncep_goesfv_bufr,ncep_gpsro_bufr,ncep_mhs_bufr,ncep_mtiasi_bufr,ncep_prep_bufr,ncep_satwnd_bufr,ncep_ssmis_bufr,npp_ompsnm_bufr,gmao_mlst_bufr
+> disc_airs_bufr,gmao_amsr2_bufr,gmao_gmi_bufr,mls_nrt_nc,ncep_1bamua_bufr,ncep_acftpfl_bufr,ncep_atms_bufr,ncep_aura_omi_bufr,ncep_avcsam_bufr,ncep_avcspm_bufr,ncep_crisfsr_bufr,ncep_goesfv_bufr,ncep_gpsro_bufr,ncep_mhs_bufr,ncep_mtiasi_bufr,ncep_prep_bufr,ncep_satwnd_bufr,ncep_ssmis_bufr,ncep_tcvitals,npp_ompsnm_bufr,n21_ompslp_nc,gmao_mlst_bufr,aura_omieff_nc,npp_ompslp_nc
 
 CHECKING OBSYSTEM? [2]
 > 1

--- a/src/Applications/GEOSdas_App/testsuites/j3drpy.input
+++ b/src/Applications/GEOSdas_App/testsuites/j3drpy.input
@@ -81,7 +81,7 @@ AeroCom? [/discover/nobackup/projects/gmao/share/gmao_ops/fvInput_4dvar/AeroCom]
 > 
 
 FVICS? [/archive/u/jstassi/restarts/GEOSadas-5_24_0]
-> /discover/nobackup/projects/gmao/dadev/rtodling/archive/541/Milan/x0050/rs/Y2023/M10/x0050.rst.20231004_15z.tar
+> /discover/nobackup/projects/gmao/dadev/rtodling/archive/543/x0053RPY/rs/Y2025/M12/x0053RPY.rst.20251230_21z.tar
 
 Run model-adjoint-related applications (0=no,1=yes)? [0]
 > 1
@@ -102,7 +102,7 @@ Verifying experiment id: [j3drpy]
 > 
 
 Ending year-month-day? [20191121]
-> 20231010
+> 20260206
 
 Length of FORECAST run segments (in hours)? [123]
 > 
@@ -150,7 +150,7 @@ Which main class of ObsSys (1: NRT; 2: MERRA; 3: MERRA-2; 4: GEOS-IT; 5: R21C)? 
 > 
 
 OBSERVING SYSTEM CLASSES?
-> disc_airs_bufr,disc_amsua_bufr,gmao_amsr2_bufr,gmao_gmi_bufr,mls_nrt_nc,ncep_1bamua_bufr,ncep_acftpfl_bufr,ncep_atms_bufr,ncep_aura_omi_bufr,ncep_avcsam_bufr,ncep_avcspm_bufr,ncep_crisfsr_bufr,ncep_goesfv_bufr,ncep_gpsro_bufr,ncep_mhs_bufr,ncep_mtiasi_bufr,ncep_prep_bufr,ncep_satwnd_bufr,ncep_ssmis_bufr,ncep_tcvitals,npp_ompsnm_bufr,r21c_npp_ompslp_nc,m2scr_n21_ompslp_nc,gmao_mlst_bufr
+> disc_airs_bufr,gmao_amsr2_bufr,gmao_gmi_bufr,mls_nrt_nc,ncep_1bamua_bufr,ncep_acftpfl_bufr,ncep_atms_bufr,ncep_aura_omi_bufr,ncep_avcsam_bufr,ncep_avcspm_bufr,ncep_crisfsr_bufr,ncep_goesfv_bufr,ncep_gpsro_bufr,ncep_mhs_bufr,ncep_mtiasi_bufr,ncep_prep_bufr,ncep_satwnd_bufr,ncep_ssmis_bufr,ncep_tcvitals,npp_ompsnm_bufr,n21_ompslp_nc,gmao_mlst_bufr,aura_omieff_nc,npp_ompslp_nc
 
 CHECKING OBSYSTEM? [2]
 > 1

--- a/src/Applications/GEOSdas_App/testsuites/j4drpy.input
+++ b/src/Applications/GEOSdas_App/testsuites/j4drpy.input
@@ -81,7 +81,7 @@ AeroCom? [/discover/nobackup/projects/gmao/share/gmao_ops/fvInput_4dvar/AeroCom]
 > 
 
 FVICS? [/archive/u/jstassi/restarts/GEOSadas-5_24_0]
-> /discover/nobackup/projects/gmao/dadev/rtodling/archive/541/Milan/x0050/rs/Y2023/M10/x0050.rst.20231004_15z.tar
+> /discover/nobackup/projects/gmao/dadev/rtodling/archive/543/x0053RPY/rs/Y2025/M12/x0053RPY.rst.20251230_21z.tar
 
 Run model-adjoint-related applications (0=no,1=yes)? [0]
 > 1
@@ -150,7 +150,7 @@ Which main class of ObsSys (1: NRT; 2: MERRA; 3: MERRA-2; 4: GEOS-IT; 5: R21C)? 
 > 
 
 OBSERVING SYSTEM CLASSES?
-> disc_airs_bufr,disc_amsua_bufr,gmao_amsr2_bufr,gmao_gmi_bufr,mls_nrt_nc,ncep_1bamua_bufr,ncep_acftpfl_bufr,ncep_atms_bufr,ncep_aura_omi_bufr,ncep_avcsam_bufr,ncep_avcspm_bufr,ncep_crisfsr_bufr,ncep_goesfv_bufr,ncep_gpsro_bufr,ncep_mhs_bufr,ncep_mtiasi_bufr,ncep_prep_bufr,ncep_satwnd_bufr,ncep_ssmis_bufr,ncep_tcvitals,npp_ompsnm_bufr,r21c_npp_ompslp_nc,m2scr_n21_ompslp_nc,gmao_mlst_bufr
+> disc_airs_bufr,gmao_amsr2_bufr,gmao_gmi_bufr,mls_nrt_nc,ncep_1bamua_bufr,ncep_acftpfl_bufr,ncep_atms_bufr,ncep_aura_omi_bufr,ncep_avcsam_bufr,ncep_avcspm_bufr,ncep_crisfsr_bufr,ncep_goesfv_bufr,ncep_gpsro_bufr,ncep_mhs_bufr,ncep_mtiasi_bufr,ncep_prep_bufr,ncep_satwnd_bufr,ncep_ssmis_bufr,ncep_tcvitals,npp_ompsnm_bufr,n21_ompslp_nc,gmao_mlst_bufr,aura_omieff_nc,npp_ompslp_nc
 
 CHECKING OBSYSTEM? [2]
 > 1

--- a/src/Applications/GEOSdas_App/testsuites/jprePP.input
+++ b/src/Applications/GEOSdas_App/testsuites/jprePP.input
@@ -1,9 +1,9 @@
-#------------
-# prePP.input
-#------------
+#-------------
+# jprePP.input
+#-------------
 
 codeID: 523f29e
-description: prePP__GEOSadas-5_43_4__agrid_C720__ogrid_C
+description: jprePP__GEOSadas-5_43_x__agrid_C720__ogrid_C
 fvsetupID: f7aaa973c7
 
 ---ENDHEADERS---
@@ -29,7 +29,7 @@ EXPID? [u000_C720]
 Check for previous use of expid (y/n)? [y]
 > n
 
-EXPDSC? [prePP__GEOSadas-5_41_2__agrid_C720__ogrid_C]
+EXPDSC? [jprePP__GEOSadas-5_41_2__agrid_C720__ogrid_C]
 > 
 
 Land Boundary Conditions? [Icarus_Updated]
@@ -38,10 +38,10 @@ Land Boundary Conditions? [Icarus_Updated]
 Catchment Model choice? [1]
 > 
 
-FVHOME? [/discover/nobackup/rtodling/prePP]
+FVHOME? [/discover/nobackup/rtodling/jprePP]
 > /discover/nobackup/projects/gmao/dadev/TSE_staging/rtodling/543/$expid
 
-The directory /discover/nobackup/projects/gmao/dadev/rtodling/prePP does not exist. Create it now? [y]
+The directory /discover/nobackup/projects/gmao/dadev/rtodling/jprePP does not exist. Create it now? [y]
 > 
 
 Processing nodes (1:Haswell, 2:Skylake, 3:Cascase, 4:Milan)? [2]
@@ -98,7 +98,7 @@ Run singular vector experiments (0=n,1=yes)? [0]
 Run analysis-sensitivity applications (0=no,1=yes)? [0]
 > 1
 
-Verifying experiment id: [prePP]
+Verifying experiment id: [jprePP]
 > 
 
 Ending year-month-day? [20210921]
@@ -207,7 +207,7 @@ Do Aerosol Analysis (y/n)? [y]
 > 
 
 AOD OBSERVING CLASSES [or type 'none']?
-> mod04_061_flk,myd04_061_flk,aeronet_obs_flk
+> mod04_061_flk,myd04_061_flk,aeronet_obs_llk
 
 Enable GAAS feedback to model (y/n)? [y]
 > 
@@ -225,19 +225,13 @@ Select group: [g0613]
 > g0613
 
 Replayed Ensemble?  [yes]
-> no
+>
 
-Use SPPT-scheme for Ensemble?  [yes]
-> 
+Replay exp name? [x0046d]
+> f5421_fpp
 
-Ensemble Resolution?  [C90]
-> C180
-
-Ensemble Vertical Levels?  [72]
-> 
-
-Experiment archive directory for ensemble restarts or 'later': [/archive/u/rtodling/prePP]
-> /discover/nobackup/projects/gmao/dadev/rtodling/archive/Restarts/5_42/f5421_fpp
+Replay archive directory? [/discover/nobackup/projects/gmao/dadev/rtodling/archive/x0046d]
+> /home/dao_ops/f5421_fpp/run/.../archive/
 
 Edit COLLECTIONS list in run/HISTORY.rc.tmpl (y/n)? [n]
 > 


### PR DESCRIPTION
This adds capability to convert ncdiag files to ioda on the fly. This can only exercised when GSI is running along JEDI analysis, .i.e., the knob SKIPGSI cannot be triggered.

User should be particularly mindful of the pointer to SWELL. This is found as the env var SWELL_INSTALL in the JEDIanaConfig.csh settings in the FVHOME/run/jedi directory; see also the GEOS-JEDI Wiki.