### PR TITLE
Updates for M21C to use a new option for precip correction

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -28,7 +28,7 @@ NCEP_Shared:
 GMAO_Shared:
   local: ./src/Shared/@GMAO_Shared
   remote: ../GMAO_Shared.git
-  tag: v1.7.2+R21C_v1.0.5
+  tag: v1.7.2+R21C_v1.0.6
   develop: R21C
 
 GMAOpyobs:
@@ -65,13 +65,13 @@ FMS:
 GEOSana_GridComp:
   local: ./src/Components/@GEOSana_GridComp
   remote: ../GEOSana_GridComp.git
-  tag: v1.5.5-R21C-7
+  tag: v1.5.5-R21C-8
   develop: R21C
 
 GEOSgcm_GridComp:
   local: ./src/Components/@GEOSgcm_GridComp
   remote: ../GEOSgcm_GridComp.git
-  tag: v1.18.1+R21C_v1.0.4
+  tag: v1.18.1+R21C_v1.0.5
   sparse: ./config/GEOSgcm_GridComp.sparse
   develop: R21C
 
@@ -195,7 +195,7 @@ RRTMGP:
 GEOSgcm_App:
   local: ./src/Applications/@GEOSgcm_App
   remote: ../GEOSgcm_App.git
-  tag: v1.9.6+R21C_v1.0.6
+  tag: v1.9.6+R21C_v1.0.7
   develop: R21C
 
 Ocean-LETKF:

--- a/src/Applications/GEOSdas_App/AGCMrc.pm
+++ b/src/Applications/GEOSdas_App/AGCMrc.pm
@@ -305,7 +305,7 @@ sub ed_g5agcm_rc {
     # uncomment precipation force except when specified
     # -------------------------------------------------
     if ( $pcp_forced ) {
-        $uncomment{"#PRECIP_FILE"}  = 1;
+        $uncomment{"#PRECIP_FILE:"}  = 1;
         $uncomment{"#USE_PP_TAPER"} = 1;
     }
 

--- a/src/Applications/GEOSdas_App/GEOSdas.csm
+++ b/src/Applications/GEOSdas_App/GEOSdas.csm
@@ -4004,7 +4004,18 @@ endif
            echo "s/>>>REGULAR_REPLAY<<</#/1"       >> sed_file
            echo "s/>>>ITER<<</$Viter_/1"           >> sed_file
            echo "s/>>>ANA0YYYYMMDDHHMN<<</$ana0date/1" >> sed_file
+           
+	   # Update Precip Correction option for MERRA-21C
+           # to transition from IMERG to scaled_clim 		
+	   set hh = `echo $nhmsb | cut -c 1-2`
+	   set check_date = ${nymdb}${hh}
+	   grep '^PRECIP_FILE:' ./AGCM.rc.tmpl > /dev/null
+	   set pcp_uncommented = $status
 
+           if ( ${check_date} >= 2025093021 && $pcp_uncommented == 0 )  then
+              echo 's/^PRECIP_FILE:/#PRECIP_FILE:/'            >> sed_file
+              echo 's/^#PRECIP_FILE_CLIMSCALE:/PRECIP_FILE_CLIMSCALE:/' >> sed_file
+           endif
            if ( -e AGCM_${Viter_}.rc.tmpl ) then
               sed -f sed_file  ./AGCM_${Viter_}.rc.tmpl > ./AGCM.rc
            else

--- a/src/Applications/GEOSdas_App/fvsetup
+++ b/src/Applications/GEOSdas_App/fvsetup
@@ -9997,8 +9997,10 @@ sub init_agcm_rc {
     #   default is based on NCA settings (but line is commented since we don't want this done)
     if ( $pcp_forced ) {
         $pcp_fntmpl = "d5_merra/Y%y4/M%m2/d5_merra.tavg1_2d_lfo_Nx_corr.%y4%m2%d2_%h230z.nc";
-        if (r21c) { $pcp_fntmpl = "precip_corr_R21C/diag/Y%y4/M%m2/R21C.tavg_1hr_prcpcorr_c360_sfc.%y4%m2%d2_%h230.nc4"};  
+        if (r21c) { $pcp_fntmpl = "precip_corr_R21C/diag/Y%y4/M%m2/R21C.tavg_1hr_prcpcorr_c360_sfc.%y4%m2%d2_%h230.nc4"};
+        if (r21c) { $pcp_sclim_fntmpl = "precip_corr_R21C/clim//M21CtoIMGv7BF.precip_clim_scale.8888%m2%d2.nc4"};	
     } else {
+	$pcp_sclim_fntmpl = "/dev/null ";
         if ( $nymd < 19890101 ) {
            $pcp_fntmpl = "d5_merra_jan79/diag/Y%y4/d5_merra_jan79.tavg1_2d_lfo_Nx_corr.%y4%m2%d2_%h230z.nc";
         } elsif ( $nymd > 19890101 && $nymd < 19980101 ) {
@@ -10008,7 +10010,7 @@ sub init_agcm_rc {
         }
     }
     AGCM_label_subst("\@PRECIP_FILE", "$pcp_fntmpl");
-    
+    AGCM_label_subst("\@PRECIP_FILE_CLIMSCALE", "$pcp_sclim_fntmpl");
 }
 
 #=======================================================================

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/AGCM.rc.tmpl
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/etc/AGCM.rc.tmpl
@@ -473,6 +473,7 @@ PCHEM::OX
 # Possible REPLAY PRECIP Files:
 # -----------------------------
 #PRECIP_FILE: ExtData/PCP/@PRECIP_FILE
+#PRECIP_FILE_CLIMSCALE: ExtData/PCP/@PRECIP_FILE_CLIMSCALE
 #
 # Latitudinal Tapering between 42.5 and 62.5 degrees mimics NCEP's approach of using GCM-based precip at high latitudes
 # --------------------

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/gcm_ensset_rc.csh
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/gcm_ensset_rc.csh
@@ -345,6 +345,17 @@ cd $ENSWORK/$member
          echo "s/>>>COUPLED<<</#/1"          >> sed_file
          echo "s/>>>MEMBER<<</${member}/1"   >> sed_file
          echo "s/>>>MEMIDX<<</${memidx}/1"   >> sed_file
+
+	 # Update Precip Correction option for MERRA-21C
+         # to transition from IMERG to scaled_clim 		
+	 set hh = `echo $nhmsb | cut -c 1-2`
+	 set check_date = ${nymdb}${hh}
+	 set pcp_forced = `grep -c '^PRECIP_FILE:' ./AGCM.rc.tmpl`
+	 
+         if ( ${check_date} >= 2025093021 && ${pcp_forced} > 0 ) then
+            echo 's/^PRECIP_FILE:/#PRECIP_FILE:/'            >> sed_file
+            echo 's/^#PRECIP_FILE_CLIMSCALE:/PRECIP_FILE_CLIMSCALE:/' >> sed_file
+         endif
          /bin/rm -f ./AGCM.rc
          sed -f sed_file  $myagcmrc > ./AGCM.rc
 

--- a/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/setup_atmens.pl
+++ b/src/Applications/NCEP_Etc/NCEP_enkf/scripts/gmao/setup_atmens.pl
@@ -536,8 +536,9 @@ sub ed_agcm_rc {
         }
 
         if ( $dopcpcor ) {
-	   if($rcd =~ /\#PRECIP_FILE/) {$rcd=~ s/\#PRECIP_FILE/PRECIP_FILE/g; }   	
-	   if($rcd =~ /\@PRECIP_FILE/) {$rcd=~ s/\@PRECIP_FILE/precip_corr_R21C\/diag\/Y%y4\/M%m2\/R21C.tavg_1hr_prcpcorr_c360_sfc.%y4%m2%d2_%h230.nc4/g; }
+	   if($rcd =~ /\#PRECIP_FILE\b/) {$rcd=~ s/\#PRECIP_FILE\b/PRECIP_FILE/g; }   	
+	   if($rcd =~ /\@PRECIP_FILE\b/) {$rcd=~ s/\@PRECIP_FILE\b/precip_corr_R21C\/diag\/Y%y4\/M%m2\/R21C.tavg_1hr_prcpcorr_c360_sfc.%y4%m2%d2_%h230.nc4/g; }
+	   if($rcd =~ /\@PRECIP_FILE_CLIMSCALE\b/) {$rcd=~ s/\@PRECIP_FILE_CLIMSCALE\b/precip_corr_R21C\/clim\/M21CtoIMGv7BF.precip_clim_scale.8888%m2%d2.nc4/g; }
 	   if($rcd =~ /\#USE_PP_TAPER/) {$rcd=~ s/\#USE_PP_TAPER/USE_PP_TAPER/g; } 
 	}
 


### PR DESCRIPTION
Commits GEOSadas resource file updates to accommodate new option of precip correction using scaled climatology and includes recent observing system mods. Note this change is both 0-diff and non-zero-diff depending on the time range. 

This PR is marked with DNA for the moment as we await tags for the following:
- [x] https://github.com/GEOS-ESM/GEOSana_GridComp/pull/238
- [x] https://github.com/GEOS-ESM/GMAO_Shared/pull/452
- [x] https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/1468
- [x] https://github.com/GEOS-ESM/GEOSgcm_App/pull/894

Once those tags have been issues, `components.yaml` must be updated with those new tags